### PR TITLE
Remove extra output from tests

### DIFF
--- a/src/board/board_test.rs
+++ b/src/board/board_test.rs
@@ -65,8 +65,6 @@ fn test_play(){
   let mut b = Board::new(19, 6.5);
 
   b = b.play(White, 14, 14);
-  b.show();
-  b.show_chains();
   assert!(b.get(14,14) == White);
 
   for i in range(1u8, 20) {


### PR DESCRIPTION
This will remove the extra output in the tests. Not even sure why this was here in the first place...
