### PR TITLE
Fixes #19 ! (At least passes the test case...)

### DIFF
--- a/src/board/board_test.rs
+++ b/src/board/board_test.rs
@@ -468,8 +468,6 @@ fn capturing_two_or_more_groups_while_playing_in_an_eye_actually_captures() {
   b = b.play(Play(Black, 5, 4)).unwrap();
   b = b.play(Play(White, 1, 1)).unwrap();
 
-  
-
   assert_eq!(b.get_coord(Coord::new(1, 1)), White);
   assert_eq!(b.get_coord(Coord::new(1, 2)), Empty);
   assert_eq!(b.get_coord(Coord::new(2, 1)), Empty);

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -339,10 +339,6 @@ impl<'a> Board<'a> {
                                                          .filter(|chain| chain.libs == 0 && chain.color != move.color())
                                                          .map(|chain| chain.id)
                                                          .collect();
-
-        println!("{}", chain_to_remove_ids);
-
-
         for &id in chain_to_remove_ids.iter() {
             self.remove_chain(id);
         }


### PR DESCRIPTION
~~Looks like using sort() and dedup() on a Vec didn't correctly remove all duplicates, which meant that when we were destroying chains, we could end up destroying a chain with the same id twice. However, since the id would now refer to another chain, that chain would be deleted instead.~~

Fix (which is better than the original code anyway): Instead of using Vec<> when we want non-repeated elements, we now use HashSet<>, which should have been using from the start. Probably better performance than sort() + dedup() as well.

This way was used originally because Rust docs says "If the vector is sorted, this removes all duplicates.". Seems it wasn't/isn't so, or at least was changed in later revisions ?

I also changed Vec->sort->dedup somewhere else in the file to HashSet, as it's better anyways.

EDIT: Hypothesis wrong, magic is happening, see comments.
