### PR TITLE
This should be an actual fix to the bug #19, and maybe to #29 ?

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -333,14 +333,20 @@ impl<'a> Board<'a> {
                                       .fold(Vec::new(), |acc, chain| acc.append(chain.coords().as_slice()));
 
 
-        let mut chain_to_remove_ids: HashSet<uint> = move.coords().neighbours(self.size)
+        let mut chain_to_remove_ids: Vec<uint> = move.coords().neighbours(self.size)
                                                          .iter()
                                                          .map(|&coord| self.get_chain(coord))
                                                          .filter(|chain| chain.libs == 0 && chain.color != move.color())
                                                          .map(|chain| chain.id)
                                                          .collect();
+
+        chain_to_remove_ids.sort();
+        chain_to_remove_ids.dedup();
+        let mut nb_of_removed_chains = 0;
+
         for &id in chain_to_remove_ids.iter() {
-            self.remove_chain(id);
+            self.remove_chain(id-nb_of_removed_chains);
+            nb_of_removed_chains += 1;
         }
 
         coords_to_remove


### PR DESCRIPTION
I think I figured out what the issue was. This also passes our unit test, but could you try it with gnugo & GoGUI (don't have those on hand right now...) ?

The problem was:
-> When removing more than one chain at once, the id of the second chain to remove might change because of the first chain being removed from the storing vector, and we didn't account for that.

Why did HashSet solve it: Pure luck. The set had an effective order inversed, which meant it removed the chains in the order that didn't impact the ids of chains to be later removed.

2 solutions: 
-> (Adopted) Use a Vec, sort and dedup it, and then count the number of removed chains so that we update the id "pointer" to reflect the changes in the chains vector.
-> Use a Vec, sort, dedup and then reverse, so that we're removing chains later in the chains vector first, not impacting the actual ids of the other chains to remove. I thought this made for a less clear code, as well as maybe not being as good performance wise (extra reverse instead of just incrementing a var), which is why I adopted the other option.
