### PR TITLE
Respond to unknown GTP commands

### DIFF
--- a/src/iomrascalai.rs
+++ b/src/iomrascalai.rs
@@ -163,7 +163,7 @@ fn gtp_mode() {
         print!("\n\n");
       }
       Quit            => {print!("= \n\n"); return;},
-      _               => ()
+      _               => {print!("? unknown command\n\n");}
     }
   }
 


### PR DESCRIPTION
The bot didn't respond at all to unknown GTP commands, which of course
means the whole program hangs.

Fixes #35
