### PR TITLE
Benchmarks for playouts on 9x9 and 19x19 boards

### DIFF
--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -25,8 +25,17 @@ use ruleset::KgsChinese;
 use test::Bencher;
 
 #[bench]
-fn bench_playout_speed(b: &mut Bencher) {
-    let game = Game::new(5, 6.5, KgsChinese);
+fn bench_9x9_playout_speed(b: &mut Bencher) {
+    let game = Game::new(9, 6.5, KgsChinese);
+    let board = game.board();
+    let playout_engine = Playout::new(board);
+
+    b.iter(|| {playout_engine.run()})
+}
+
+#[bench]
+fn bench_19x19_playout_speed(b: &mut Bencher) {
+    let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
     let playout_engine = Playout::new(board);
 


### PR DESCRIPTION
I changed the playout benchmark from a 5x5 board to a 9x9 board and added one for a 19x19 board. The results I get on my machine are as follows:

```
test board::test::bench_play_method                 ... bench:      1523 ns/iter (+/- 99)
test engine::mc::test::bench_engine_move_generation ... bench:  27169002 ns/iter (+/- 3936689)
test playout::test::bench_19x19_playout_speed       ... bench:  90832645 ns/iter (+/- 10716123)
test playout::test::bench_9x9_playout_speed         ... bench:  18685251 ns/iter (+/- 8058659)
```

So, a 9x9 playout takes 0.01s (so 100pps) and a 19x19 one takes 0.09s (11pps). I'm a bit surprised by the results as the old benchmarking code reported 2pps for a 9x9 code. @TisButMe do you have any idea where this difference may come from?