### PR TITLE
Cache Coord.neighbours

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -211,15 +211,15 @@ impl<'a> Board<'a> {
         }
 
         // We check if the new move is inside the board (and if it is, if there is no stone there)
-        if m.coords().is_inside(self.size) {
-            if self.get_coord(m.coords()) != Empty {
+        if m.coord().is_inside(self.size) {
+            if self.get_coord(m.coord()) != Empty {
                 return Err(IllegalMove::IntersectionNotEmpty);
             }
         } else {
             return Err(IllegalMove::PlayOutOfBoard);
         }
 
-        if self.ko.is_some() && m.coords() == self.ko.unwrap() {
+        if self.ko.is_some() && m.coord() == self.ko.unwrap() {
             return Err(IllegalMove::Ko);
         }
 
@@ -237,7 +237,7 @@ impl<'a> Board<'a> {
         let adv_stones_removed = new_board.remove_adv_chains_with_no_libs_close_to(&m);
         new_board.update_all();
 
-        let final_chain_id = new_board.get_chain(m.coords()).id;
+        let final_chain_id = new_board.get_chain(m.coord()).id;
         new_board.update_libs(final_chain_id);
 
         let mut friend_stones_removed = Vec::new();
@@ -246,10 +246,10 @@ impl<'a> Board<'a> {
             for i in range(1, new_board.chains.len()) {
                 new_board.update_libs(i);
             }
-        } else if new_board.get_chain(m.coords()).libs == 0 {
+        } else if new_board.get_chain(m.coord()).libs == 0 {
             if self.ruleset.suicide_allowed() {
-                friend_stones_removed.push_all(new_board.get_chain(m.coords()).coords().as_slice());
-                let to_remove_id = new_board.get_chain(m.coords()).id;
+                friend_stones_removed.push_all(new_board.get_chain(m.coord()).coords().as_slice());
+                let to_remove_id = new_board.get_chain(m.coord()).id;
                 new_board.remove_chain(to_remove_id);
                 new_board.update_all_after_id(to_remove_id);
             } else {
@@ -269,7 +269,7 @@ impl<'a> Board<'a> {
     }
 
     fn find_neighbouring_friendly_chains_ids(&self, m: &Move) -> Vec<uint> {
-        let mut friend_neigh_chains_id: Vec<uint> = self.neighbours(m.coords())
+        let mut friend_neigh_chains_id: Vec<uint> = self.neighbours(m.coord())
                   .iter()
                   .filter(|&c| c.is_inside(self.size) && self.get_coord(*c) == *m.color())
                   .map(|&c| self.get_chain(c).id)
@@ -297,7 +297,7 @@ impl<'a> Board<'a> {
             0 => self.create_new_chain(m),
             1 => {
                 let final_chain_id = friend_neigh_chains_id[0];
-                self.add_coord_to_chain(m.coords(), final_chain_id);
+                self.add_coord_to_chain(m.coord(), final_chain_id);
             },
             _ => {
                 // Note: We know that friend_neigh_chains_id is sorted, so whatever chains we remove,
@@ -306,7 +306,7 @@ impl<'a> Board<'a> {
                 let mut nb_removed_chains = 0;
 
                 // We assign the stone to the final chain
-                self.add_coord_to_chain(m.coords(), final_chain_id);
+                self.add_coord_to_chain(m.coord(), final_chain_id);
 
                 for &other_chain_old_id in friend_neigh_chains_id.slice(1, friend_neigh_chains_id.len()).iter() {
                     // The ids stored in friend_neigh_chains_id may be out of date since we remove chains from self.chains
@@ -382,13 +382,13 @@ impl<'a> Board<'a> {
 
     // Returns a vector of the coords where stones where removed.
     fn remove_adv_chains_with_no_libs_close_to(&mut self, m: &Move) -> Vec<Coord> {
-        let coords_to_remove = self.neighbours(m.coords()).iter()
+        let coords_to_remove = self.neighbours(m.coord()).iter()
                                       .map(|&coord| self.get_chain(coord))
                                       .filter(|chain| chain.libs == 0 && chain.color != *m.color())
                                       .fold(Vec::new(), |acc, chain| acc + chain.coords().as_slice());
 
 
-        let mut chain_to_remove_ids: Vec<uint> = self.neighbours(m.coords())
+        let mut chain_to_remove_ids: Vec<uint> = self.neighbours(m.coord())
                                                          .iter()
                                                          .map(|&coord| self.get_chain(coord))
                                                          .filter(|chain| chain.libs == 0 && chain.color != *m.color())
@@ -421,9 +421,9 @@ impl<'a> Board<'a> {
     fn create_new_chain(&mut self, m: &Move) {
         let new_chain_id    = self.chains.len();
         let mut new_chain   = Chain::new(new_chain_id, *m.color());
-        new_chain.add_stone(m.coords());
+        new_chain.add_stone(m.coord());
         self.chains.push(new_chain);
-        self.board[m.coords().to_index(self.size)] = new_chain_id;
+        self.board[m.coord().to_index(self.size)] = new_chain_id;
         self.update_libs(new_chain_id);
     }
 

--- a/src/board/movement/mod.rs
+++ b/src/board/movement/mod.rs
@@ -60,7 +60,7 @@ impl Move {
         }
     }
 
-    pub fn coords(&self) -> Coord {
+    pub fn coord(&self) -> Coord {
         match *self {
             Play(_, col, row) => Coord::new(col, row),
             Pass(_)           => panic!("You have tried to get the coords() of a Pass move")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,7 +67,7 @@ impl Driver {
             g = match g.play(m) {
                 Ok(g) => g,
                 Err(IllegalMove::PlayOutOfBoard) =>
-                    panic!("You can't play on invalid coordinates ({} {})", m.coords().col, m.coords().row),
+                    panic!("You can't play on invalid coordinates ({} {})", m.coord().col, m.coord().row),
                 Err(IllegalMove::IntersectionNotEmpty)  =>
                     panic!("You can't play on a non-empty intersection !"),
                 Err(IllegalMove::SuicidePlay)           =>

--- a/src/game/hash.rs
+++ b/src/game/hash.rs
@@ -62,7 +62,7 @@ impl ZobristHashTable {
     }
 
     pub fn add_stone_to_hash(&self, hash: u64, m: &Move) -> u64 {
-        hash ^ self.get_hash_for(&Play(Empty, m.coords().col, m.coords().row)) ^ self.get_hash_for(m)
+        hash ^ self.get_hash_for(&Play(Empty, m.coord().col, m.coord().row)) ^ self.get_hash_for(m)
     }
 
     pub fn remove_stone_from_hash(&self, hash: u64, m: &Move) -> u64 {
@@ -77,6 +77,6 @@ impl ZobristHashTable {
             White => 2
         };
 
-        self.table[color_as_index*self.size as uint + (m.coords().row-1) as uint * self.size as uint + m.coords().col as uint - 1]
+        self.table[color_as_index*self.size as uint + (m.coord().row-1) as uint * self.size as uint + m.coord().col as uint - 1]
     }
 }


### PR DESCRIPTION
This caches the neighbours of each `Coord` inside the board. This results in a modest speed increase of the playouts for 9x9 from 54pps to 62pps.

Fixes #66