### PR TITLE
Store the actual liberties in the Chains

### DIFF
--- a/src/board/chain/mod.rs
+++ b/src/board/chain/mod.rs
@@ -29,19 +29,36 @@ mod test;
 
 #[derive(Clone, Eq, PartialEq, Show)]
 pub struct Chain {
-    coords:   Vec<Coord>,
-    libs:     HashSet<Coord>,
-    pub color: Color,
-    pub id:   usize,
+    color:  Color,
+    coords: Vec<Coord>,
+    id:     usize,
+    libs:   HashSet<Coord>,
 }
 
 impl Chain {
-    pub fn new(id: usize, color: Color) -> Chain {
-        Chain {coords: Vec::new(), color: color, id: id, libs: HashSet::new()}
+    pub fn new(id: usize, color: Color, c: Coord, libs: Vec<Coord>) -> Chain {
+        Chain {
+            color:  color,
+            coords: vec!(c),
+            id:     id,
+            libs:   libs.into_iter().collect(),
+        }
     }
 
-    pub fn add_stone(&mut self, coord: Coord) {
-        self.coords.push(coord);
+    pub fn color(&self) -> Color {
+        self.color
+    }
+
+    pub fn coords<'a>(&'a self) -> &'a Vec<Coord> {
+        &self.coords
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn set_id(&mut self, id: usize) {
+        self.id = id;
     }
 
     pub fn add_liberty(&mut self, coord: Coord) {
@@ -57,10 +74,6 @@ impl Chain {
         for &l in c.libs.iter() {
             self.libs.insert(l);
         }
-    }
-
-    pub fn coords<'a>(&'a self) -> &'a Vec<Coord> {
-        &self.coords
     }
 
     pub fn is_captured(&self) -> bool {

--- a/src/board/chain/mod.rs
+++ b/src/board/chain/mod.rs
@@ -21,41 +21,53 @@
  ************************************************************************/
 
 use board::Color;
-use board::coord::Coord;
+use board::Coord;
+
+use std::collections::HashSet;
 
 mod test;
 
 #[derive(Clone, Eq, PartialEq, Show)]
 pub struct Chain {
-    pub id   : usize,
+    coords:   Vec<Coord>,
+    libs:     HashSet<Coord>,
     pub color: Color,
-    pub libs : usize,
-    coords   : Vec<Coord>
+    pub id:   usize,
 }
 
 impl Chain {
     pub fn new(id: usize, color: Color) -> Chain {
-        Chain {coords: Vec::new(), color: color, id: id, libs: 1}
+        Chain {coords: Vec::new(), color: color, id: id, libs: HashSet::new()}
     }
 
     pub fn add_stone(&mut self, coord: Coord) {
         self.coords.push(coord);
     }
 
+    pub fn add_liberty(&mut self, coord: Coord) {
+        self.libs.insert(coord);
+    }
+
+    pub fn remove_liberty(&mut self, coord: Coord) {
+        self.libs.remove(&coord);
+    }
+
     pub fn merge(&mut self, c: &Chain) {
         self.coords.push_all(c.coords.as_slice());
+        for &l in c.libs.iter() {
+            self.libs.insert(l);
+        }
     }
 
     pub fn coords<'a>(&'a self) -> &'a Vec<Coord> {
         &self.coords
     }
 
+    pub fn is_captured(&self) -> bool {
+        self.libs.len() == 0
+    }
+
     pub fn show(&self) -> String {
-        self.coords
-            .iter()
-            .fold(
-                format!("{:<3}| {:?}, libs: {:2}, stones: ", self.id, self.color, self.libs),
-                |s, c| s + format!(" {},{} |", c.col, c.row).as_slice()
-            )
+        format!("{:<3}| {:?}, libs: {:?}, stones: {:?}", self.id, self.color, self.libs, self.coords)
     }
 }

--- a/src/board/chain/mod.rs
+++ b/src/board/chain/mod.rs
@@ -53,6 +53,10 @@ impl Chain {
         &self.coords
     }
 
+    pub fn liberties(&self) -> &HashSet<Coord> {
+        &self.libs
+    }
+
     pub fn id(&self) -> usize {
         self.id
     }
@@ -69,11 +73,8 @@ impl Chain {
         self.libs.remove(&coord);
     }
 
-    pub fn merge(&mut self, c: &Chain) {
-        self.coords.push_all(c.coords.as_slice());
-        for &l in c.libs.iter() {
-            self.libs.insert(l);
-        }
+    pub fn add_coord(&mut self, coord: Coord) {
+        self.coords.push(coord);
     }
 
     pub fn is_captured(&self) -> bool {

--- a/src/board/chain/test.rs
+++ b/src/board/chain/test.rs
@@ -6,11 +6,11 @@ use board::Coord;
 
 #[test]
 fn show_returns_a_legible_string_for_the_chain() {
-    let mut c1 = Chain::new(1, Black, Coord::new(7,7), vec!(Coord::new(1,1)));
+    let mut c = Chain::new(1, Black, Coord::new(7,7), vec!(Coord::new(1,1)));
 
-    c1.merge(&Chain::new(2, Black, Coord::new(7,8), vec!()));
-    c1.merge(&Chain::new(2, Black, Coord::new(7,9), vec!()));
+    c.add_coord(Coord::new(7,8));
+    c.add_coord(Coord::new(7,9));
 
     let expected = String::from_str("1  | Black, libs: HashSet {\"(1,1)\"}, stones: [\"(7,7)\", \"(7,8)\", \"(7,9)\"]");
-    assert_eq!(c1.show(), expected);
+    assert_eq!(c.show(), expected);
 }

--- a/src/board/chain/test.rs
+++ b/src/board/chain/test.rs
@@ -1,68 +1,15 @@
 #![cfg(test)]
 
 use board::Black;
-use board::chain::Chain;
-use board::coord::Coord;
-
-#[test]
-fn add_stone_adds_a_stone() {
-    let mut c1 = Chain::new(1, Black);
-    c1.add_stone(Coord::new(14,14));
-
-    assert_eq!(c1.coords().len(), 1);
-}
-
-#[test]
-fn add_stone_adds_the_correct_stone() {
-    let mut c1 = Chain::new(1, Black);
-    c1.add_stone(Coord::new(14,14));
-
-    assert_eq!(c1.coords()[0], Coord::new( 14, 14));
-}
-
-#[test]
-fn merge_adds_all_the_coords_of_the_merged_chain() {
-    let mut c1 = Chain::new(1, Black);
-    let mut c2 = Chain::new(2, Black);
-
-    c2.add_stone(Coord::new(10,10));
-    c2.add_stone(Coord::new(10,11));
-    c2.add_stone(Coord::new(11,10));
-
-    c1.merge(&c2);
-
-    assert_eq!(c1.coords().len(), 3);
-    assert!(c1.coords().contains(&Coord::new(10,10)));
-    assert!(c1.coords().contains(&Coord::new(10,11)));
-    assert!(c1.coords().contains(&Coord::new(11,10)));
-}
-
-#[test]
-fn merge_doesnt_remove_the_previous_stones() {
-    let mut c1 = Chain::new(1, Black);
-    let mut c2 = Chain::new(2, Black);
-
-    c2.add_stone(Coord::new(10,10));
-    c2.add_stone(Coord::new(10,11));
-
-    c1.merge(&c2);
-    c1.add_stone(Coord::new(7,7));
-    c1.add_stone(Coord::new(7,8));
-    c1.add_stone(Coord::new(7,9));
-
-    assert!(c1.coords().contains(&Coord::new(7,7)));
-    assert!(c1.coords().contains(&Coord::new(7,8)));
-    assert!(c1.coords().contains(&Coord::new(7,9)));
-}
+use board::Chain;
+use board::Coord;
 
 #[test]
 fn show_returns_a_legible_string_for_the_chain() {
-    let mut c1 = Chain::new(1, Black);
+    let mut c1 = Chain::new(1, Black, Coord::new(7,7), vec!(Coord::new(1,1)));
 
-    c1.add_stone(Coord::new(7,7));
-    c1.add_stone(Coord::new(7,8));
-    c1.add_stone(Coord::new(7,9));
-    c1.add_liberty(Coord::new(1,1));
+    c1.merge(&Chain::new(2, Black, Coord::new(7,8), vec!()));
+    c1.merge(&Chain::new(2, Black, Coord::new(7,9), vec!()));
 
     let expected = String::from_str("1  | Black, libs: HashSet {\"(1,1)\"}, stones: [\"(7,7)\", \"(7,8)\", \"(7,9)\"]");
     assert_eq!(c1.show(), expected);

--- a/src/board/chain/test.rs
+++ b/src/board/chain/test.rs
@@ -62,8 +62,8 @@ fn show_returns_a_legible_string_for_the_chain() {
     c1.add_stone(Coord::new(7,7));
     c1.add_stone(Coord::new(7,8));
     c1.add_stone(Coord::new(7,9));
-    c1.libs = 8;
+    c1.add_liberty(Coord::new(1,1));
 
-    let expected = String::from_str("1  | Black, libs:  8, stones:  7,7 | 7,8 | 7,9 |");
+    let expected = String::from_str("1  | Black, libs: HashSet {\"(1,1)\"}, stones: [\"(7,7)\", \"(7,8)\", \"(7,9)\"]");
     assert_eq!(c1.show(), expected);
 }

--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -19,9 +19,8 @@
  * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
  *                                                                      *
  ************************************************************************/
-use core::fmt::Show;
+use core::fmt;
 use std::cmp::Eq;
-use std::fmt;
 
 mod test;
 
@@ -100,9 +99,9 @@ impl Coord {
     }
 }
 
-impl Show for Coord {
+impl fmt::Show for Coord {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = format!("{}, {}", self.col, self.row);
+        let s = format!("({},{})", self.col, self.row);
         s.fmt(f)
     }
 }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -19,6 +19,7 @@
  * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
  *                                                                      *
  ************************************************************************/
+pub use board::chain::Chain;
 pub use board::coord::Coord;
 pub use board::movement::Move;
 pub use board::movement::Pass;
@@ -26,7 +27,6 @@ pub use board::movement::Play;
 pub use self::Color::Black;
 pub use self::Color::Empty;
 pub use self::Color::White;
-use board::chain::Chain;
 use ruleset::Ruleset;
 use score::Score;
 
@@ -78,10 +78,22 @@ impl Color {
     }
 }
 
+struct Territory {
+    color:  Color,
+    coords: Vec<Coord>,
+}
+
+impl Territory {
+
+    pub fn new() -> Territory {
+        Territory { color: Empty, coords: Vec::new() }
+    }
+}
+
 #[derive(Show)]
 pub struct Board<'a> {
     adv_stones_removed:    Vec<Coord>,
-    board:                 Vec<usize>,
+    board:                 Vec<Option<usize>>,
     chains:                Vec<Chain>,
     consecutive_passes:    u8,
     friend_stones_removed: Vec<Coord>,
@@ -115,8 +127,8 @@ impl<'a> Board<'a> {
     pub fn new(size: u8, komi: f32, ruleset: Ruleset) -> Board<'a> {
         Board {
             adv_stones_removed:    Vec::new(),
-            board:                 range(0, size as usize*size as usize).map(|_| 0).collect(),
-            chains:                vec!(Chain::new(0, Empty)),
+            board:                 range(0, size as usize*size as usize).map(|_| None).collect(),
+            chains:                Vec::new(),
             consecutive_passes:    0,
             friend_stones_removed: Vec::new(),
             ko:                    None,
@@ -142,16 +154,22 @@ impl<'a> Board<'a> {
 
     pub fn color(&self, c: Coord) -> Color {
         if c.is_inside(self.size) {
-            self.get_chain(c).color
+            match self.get_chain(c) {
+                Some(chain) => chain.color(),
+                None        => Empty,
+            }
         } else {
             panic!("You have requested a stone outside of the board");
         }
     }
 
-    pub fn get_chain<'b>(&'b self, c: Coord) -> &'b Chain {
+    pub fn get_chain<'b>(&'b self, c: Coord) -> Option<&'b Chain> {
         if c.is_inside(self.size) {
-            let chain_id = self.board[c.to_index(self.size)];
-            &self.chains[chain_id]
+            let possible_chain_id = self.board[c.to_index(self.size)];
+            match possible_chain_id {
+                Some(chain_id) => Some(&self.chains[chain_id]),
+                None           => None
+            }
         } else {
             panic!("You have requested a chain outside of the board");
         }
@@ -228,143 +246,141 @@ impl<'a> Board<'a> {
         new_board.previous_player    = *m.color();
 
         new_board.consecutive_passes = 0;
-
+        // Create new chain or merge it with the neighbouring ones. It
+        // removes coord from the list of liberties of the
+        // neighbouring chains.
         new_board.merge_or_create_chain(&m);
-        // We then update the libs of all chains of the opposite color
-        new_board.update_chains_libs_of(m.color().opposite());
-
-        let adv_stones_removed = new_board.remove_adv_chains_with_no_libs_close_to(&m);
-        new_board.update_all();
-
-        let final_chain_id = new_board.get_chain(m.coord()).id;
-        new_board.update_libs(final_chain_id);
-
-        let mut friend_stones_removed = Vec::new();
-
-        if adv_stones_removed.len() > 0 {
-            for i in range(1, new_board.chains.len()) {
-                new_board.update_libs(i);
-            }
-        } else if new_board.get_chain(m.coord()).is_captured() {
-            if self.ruleset.suicide_allowed() {
-                friend_stones_removed.push_all(new_board.get_chain(m.coord()).coords().as_slice());
-                let to_remove_id = new_board.get_chain(m.coord()).id;
-                new_board.remove_chain(to_remove_id);
-                new_board.update_all_after_id(to_remove_id);
+        // Updates the liberties of the opposing neighbouring chains
+        new_board.update_libs_of_adjacent_opposing_chains(&m);
+        // Removes captured opposing chains
+        new_board.adv_stones_removed = new_board.remove_captured_opponent_stones(&m);
+        // Adds removed stones as liberties to the neighbouring chains
+        new_board.add_removed_adv_stones_as_libs(&m);
+        // Checks for suicide play
+        if new_board.get_chain(m.coord()).unwrap().is_captured() {
+            if new_board.ruleset.suicide_allowed() {
+                new_board.friend_stones_removed = new_board.remove_suicide_chain(&m);
+                new_board.add_removed_friendly_stones_as_libs(&m);
             } else {
                 return Err(IllegalMove::SuicidePlay)
             }
         }
-        if adv_stones_removed.len() == 1 && friend_stones_removed.len() == 0 {
-            let coord = adv_stones_removed[0];
+        if new_board.adv_stones_removed.len() == 1 && new_board.friend_stones_removed.len() == 0 {
+            let coord = new_board.adv_stones_removed[0];
             new_board.ko = Some(coord);
         } else {
             new_board.ko = None;
         }
-
-        new_board.friend_stones_removed = friend_stones_removed;
-        new_board.adv_stones_removed = adv_stones_removed;
         Ok(new_board)
+    }
+
+    fn add_removed_adv_stones_as_libs(&mut self, m: &Move) {
+        let color = *m.color();
+        let mut libs: HashMap<Coord, Vec<usize>> = HashMap::new();
+        for &coord in self.adv_stones_removed.iter() {
+            let chain_ids = self.neighbours(coord).
+                iter()
+                .map(|&c| self.get_chain(c))
+                .filter(|possible_chain| possible_chain.is_some())
+                .map(|possible_chain| possible_chain.unwrap())
+                .filter(|chain| chain.color() == color)
+                .map(|chain| chain.id())
+                .collect();
+            libs.insert(coord, chain_ids);
+        }
+        for (&coord, chain_ids) in libs.iter() {
+            for &chain_id in chain_ids.iter() {
+                self.chains[chain_id].add_liberty(coord);
+            }
+        }
+    }
+
+    fn add_removed_friendly_stones_as_libs(&mut self, m: &Move) {
+        let color = m.color().opposite();
+        let mut libs: HashMap<Coord, Vec<usize>> = HashMap::new();
+        for &coord in self.adv_stones_removed.iter() {
+            let chain_ids = self.neighbours(coord).
+                iter()
+                .map(|&c| self.get_chain(c))
+                .filter(|possible_chain| possible_chain.is_some())
+                .map(|possible_chain| possible_chain.unwrap())
+                .filter(|chain| chain.color() == color)
+                .map(|chain| chain.id())
+                .collect();
+            libs.insert(coord, chain_ids);
+        }
+        for (&coord, chain_ids) in libs.iter() {
+            for &chain_id in chain_ids.iter() {
+                self.chains[chain_id].add_liberty(coord);
+            }
+        }
+    }
+
+    fn update_libs_of_adjacent_opposing_chains(&mut self, m: &Move) {
+        let coord = m.coord();
+        let color = m.color().opposite();
+        let adv_chains_ids: HashSet<usize> = self.neighbours(coord)
+            .iter()
+            .map(|&c| self.get_chain(c))
+            .filter(|possible_chain| possible_chain.is_some())
+            .map(|possible_chain| possible_chain.unwrap())
+            .filter(|chain| chain.color() == color)
+            .map(|chain| chain.id())
+            .collect();
+        for &id in adv_chains_ids.iter() {
+            self.chains[id].remove_liberty(coord);
+        }
     }
 
     fn find_neighbouring_friendly_chains_ids(&self, m: &Move) -> Vec<usize> {
         let mut friend_neigh_chains_id: Vec<usize> = self.neighbours(m.coord())
-                  .iter()
-                  .filter(|&c| c.is_inside(self.size) && self.color(*c) == *m.color())
-                  .map(|&c| self.get_chain(c).id)
-                  .collect();
-
-        // We need to sort the chain by ascending id so that later we know that friend_neigh_chains_id[0] has the lowest id.
-        // It also helps with keeping track of the ids of the chain yet-to-merge as their ids will always decrease by nb of chains
-        // merged before them.
+            .iter()
+            .map(|&c| self.get_chain(c))
+            .filter(|possible_chain| possible_chain.is_some())
+            .map(|possible_chain| possible_chain.unwrap())
+            .filter(|chain| chain.color() == *m.color())
+            .map(|chain| chain.id())
+            .collect();
+        // We need to sort the chain by ascending id so that later we
+        // know that friend_neigh_chains_id[0] has the lowest id. It
+        // also helps with keeping track of the ids of the chain
+        // yet-to-merge as their ids will always decrease by nb of
+        // chains merged before them.
         friend_neigh_chains_id.sort();
         friend_neigh_chains_id.dedup();
         friend_neigh_chains_id
     }
 
     fn merge_or_create_chain(&mut self, m: &Move) {
-        let friend_neigh_chains_id = self.find_neighbouring_friendly_chains_ids(m);
-
-        /*
-         * If there is 0 friendly neighbouring chain, we create one, and assign the coord played to that new chain.
-         * If there is 1, we assign the stone to that chain.
-         * If there are more, we assign the stone to one chain, then merge the others into that chain, then remove the old chains from
-         * board.chains, then we lower by 1 the ids of all stones with chain ids higher than the removed chains,
-         * and finally we reassign the correct chain_id to each stone in the final chain.
-        */
-        match friend_neigh_chains_id.len() {
-            0 => self.create_new_chain(m),
-            1 => {
-                let final_chain_id = friend_neigh_chains_id[0];
-                self.add_coord_to_chain(m.coord(), final_chain_id);
-            },
-            _ => {
-                // Note: We know that friend_neigh_chains_id is sorted, so whatever chains we remove,
-                // we know that the id of the final_chain is still valid.
-                let final_chain_id        = friend_neigh_chains_id[0];
-                let mut nb_removed_chains = 0;
-
-                // We assign the stone to the final chain
-                self.add_coord_to_chain(m.coord(), final_chain_id);
-
-                for &other_chain_old_id in friend_neigh_chains_id.slice(1, friend_neigh_chains_id.len()).iter() {
-                    // The ids stored in friend_neigh_chains_id may be out of date since we remove chains from self.chains
-                    // These id is the correct one at this step of the removals
-                    let other_chain_id = other_chain_old_id - nb_removed_chains;
-
-                    // We merge the other chain into the final chain.
-                    let other_chain = self.chains[other_chain_id].clone();
-                    self.chains[final_chain_id].merge(&other_chain);
-
-                    // We remove the old chain.
-                    self.chains.remove(other_chain_id);
-
-                    // We update the ids inside the chains
-                    self.update_chains_ids_after_id(other_chain_id);
-
-                    nb_removed_chains += 1;
-                }
-
-                self.update_board_ids_after_id(final_chain_id);
-            }
+        let mut chain_ids = self.find_neighbouring_friendly_chains_ids(m);
+        let new_chain_id = self.create_new_chain(m);
+        chain_ids.push(new_chain_id);
+        let final_chain_id = chain_ids[0];
+        let mut nb_removed_chains = 0;
+        for &other_chain_old_id in chain_ids.slice(1, chain_ids.len()).iter() {
+            let other_chain_id = other_chain_old_id - nb_removed_chains;
+            // We merge the other chain into the final chain.
+            let other_chain = self.chains[other_chain_id].clone();
+            self.chains[final_chain_id].merge(&other_chain);
+            // We remove the old chain.
+            self.move_stones_to_chain_and_remove(other_chain_id, final_chain_id);
+            nb_removed_chains += 1;
         }
-    }
-
-    fn update_libs(&mut self, chain_id: usize) {
-        for &coord in self.chains[chain_id].coords().clone().iter() {
-            for &n in self.neighbours(coord).clone().iter() {
-                if self.color(n) == Empty {
-                    self.chains[chain_id].add_liberty(n);
-                } else {
-                    self.chains[chain_id].remove_liberty(n);
-                }
-            }
-        }
-    }
-
-    fn update_chains_libs_of(&mut self, color: Color) {
-        let adv_chains_ids: HashSet<usize> = self.chains
-                  .iter()
-                  .filter(|c| c.color == color)
-                  .map(|c| c.id)
-                  .collect();
-
-        for id in adv_chains_ids.iter() {
-            self.update_libs(*id);
-        }
+        // Removes the played stone from the liberty
+        self.chains[final_chain_id].remove_liberty(m.coord());
     }
 
     fn update_board_ids_after_id(&mut self, id: usize) {
         for i in range(id, self.chains.len()) {
             for &coord in self.chains[i].coords().iter() {
-                self.board[coord.to_index(self.size)] = i;
+                self.board[coord.to_index(self.size)] = Some(i);
             }
         }
     }
 
     fn update_chains_ids_after_id(&mut self, removed_chain_id: usize) {
         for i in range(removed_chain_id, self.chains.len()) {
-            self.chains[i].id = i;
+            self.chains[i].set_id(i);
         }
     }
 
@@ -373,35 +389,40 @@ impl<'a> Board<'a> {
         self.update_chains_ids_after_id(id);
     }
 
-    fn update_all(&mut self) {
-        self.update_all_after_id(0);
-    }
-
-    // Returns a vector of the coords where stones where removed.
-    fn remove_adv_chains_with_no_libs_close_to(&mut self, m: &Move) -> Vec<Coord> {
+    fn remove_captured_opponent_stones(&mut self, m: &Move) -> Vec<Coord> {
+        let coord = m.coord();
         let color = m.color().opposite();
-        let coords_to_remove = self.neighbours(m.coord()).iter()
-            .map(|&coord| self.get_chain(coord))
-            .filter(|chain| chain.is_captured() && chain.color == color)
-            .fold(Vec::new(), |acc, chain| acc + chain.coords().as_slice());
-
-
-        let mut chain_to_remove_ids: Vec<usize> = self.neighbours(m.coord())
+        let coords_to_remove = self.neighbours(coord)
             .iter()
-            .map(|&coord| self.get_chain(coord))
-            .filter(|chain| chain.is_captured() && chain.color == color)
-            .map(|chain| chain.id)
+            .map(|&c| self.get_chain(c))
+            .filter(|possible_chain| possible_chain.is_some())
+            .map(|possible_chain| possible_chain.unwrap())
+            .filter(|chain| chain.is_captured() && chain.color() == color)
+            .flat_map(|chain| chain.coords().iter())
+            .cloned()
             .collect();
-
-        chain_to_remove_ids.sort();
-        chain_to_remove_ids.dedup();
+        let mut chains_to_remove: Vec<usize> = self.neighbours(coord)
+            .iter()
+            .map(|&c| self.get_chain(c))
+            .filter(|possible_chain| possible_chain.is_some())
+            .map(|possible_chain| possible_chain.unwrap())
+            .filter(|chain| chain.is_captured() && chain.color() == color)
+            .map(|chain| chain.id())
+            .collect();
+        chains_to_remove.sort();
+        chains_to_remove.dedup();
         let mut nb_of_removed_chains = 0;
-
-        for &id in chain_to_remove_ids.iter() {
+        for &id in chains_to_remove.iter() {
             self.remove_chain(id-nb_of_removed_chains);
             nb_of_removed_chains += 1;
         }
+        coords_to_remove
+    }
 
+    fn remove_suicide_chain(&mut self, m: &Move) -> Vec<Coord> {
+        let coords_to_remove = self.get_chain(m.coord()).unwrap().coords().clone();
+        let chain_id = self.get_chain(m.coord()).unwrap().id();
+        self.remove_chain(chain_id);
         coords_to_remove
     }
 
@@ -413,25 +434,36 @@ impl<'a> Board<'a> {
         }
 
         self.chains.remove(id);
-        self.update_chains_ids_after_id(id);
+        self.update_all_after_id(id);
     }
 
-    fn create_new_chain(&mut self, m: &Move) {
+    fn move_stones_to_chain_and_remove(&mut self, old_chain_id: usize, new_chain_id: usize) {
+        let coords_to_move = self.chains[old_chain_id].coords().clone();
+
+        for &coord in coords_to_move.iter() {
+            self.board[coord.to_index(self.size)] = Some(new_chain_id);
+        }
+
+        self.chains.remove(old_chain_id);
+        self.update_all_after_id(new_chain_id);
+
+    }
+
+    fn create_new_chain(&mut self, m: &Move) -> usize {
         let new_chain_id    = self.chains.len();
-        let mut new_chain   = Chain::new(new_chain_id, *m.color());
-        new_chain.add_stone(m.coord());
+        let mut new_chain   = Chain::new(
+            new_chain_id, *m.color(), m.coord(), self.liberties(&m.coord()));
         self.chains.push(new_chain);
-        self.board[m.coord().to_index(self.size)] = new_chain_id;
-        self.update_libs(new_chain_id);
+        self.board[m.coord().to_index(self.size)] = Some(new_chain_id);
+        new_chain_id
     }
 
-    fn add_coord_to_chain(&mut self, coord: Coord, chain_id: usize) {
-        self.chains[chain_id].add_stone(coord);
-       self.board[coord.to_index(self.size)] = chain_id;
+    fn liberties(&self, c: &Coord) -> Vec<Coord> {
+        self.neighbours(*c).iter().filter(|&c| self.color(*c) == Empty).cloned().collect()
     }
 
     fn remove_stone(&mut self, c: Coord) {
-        self.board[c.to_index(self.size)] = 0;
+        self.board[c.to_index(self.size)] = None;
     }
 
     pub fn score(&self) -> Score {
@@ -443,42 +475,47 @@ impl<'a> Board<'a> {
     }
 
     fn score_tt(&self) -> (usize, usize) {
-        let mut black_score = self.board.iter()
-                                        .filter(|&id| self.chains[*id].color == Black)
-                                        .count();
-
-
-        let mut white_score = self.board.iter()
-                                        .filter(|&id| self.chains[*id].color == White)
-                                        .count();
-
-        let mut empty_intersections = Vec::<Coord>::new();
-        for i in range(0, self.board.len()) {
-            let id = self.board[i];
-
-            if self.chains[id].color == Empty {
-                let c = Coord::from_index(i, self.size);
-                empty_intersections.push(c);
+        let mut black_score = 0;
+        let mut white_score = 0;
+        for &possible_id in self.board.iter() {
+            match possible_id {
+                Some(id) => {
+                    if self.chains[id].color() == Black {
+                        black_score += 1;
+                    } else {
+                        white_score += 1;
+                    }
+                },
+                None => {}
             }
         }
-
+        let mut empty_intersections = Vec::<Coord>::new();
+        for i in range(0, self.board.len()) {
+            let possible_chain_id = self.board[i];
+            match possible_chain_id {
+                None => {
+                    let c = Coord::from_index(i, self.size);
+                    empty_intersections.push(c);
+                },
+                Some(_) => {}
+            }
+        }
         while empty_intersections.len() > 0 {
             let territory = self.build_territory_chain(empty_intersections[0]);
 
             match territory.color {
-                Black => black_score += territory.coords().len(),
-                White => white_score += territory.coords().len(),
+                Black => black_score += territory.coords.len(),
+                White => white_score += territory.coords.len(),
                 Empty => () // This territory is not enclosed by a single color
             }
 
-            empty_intersections = empty_intersections.into_iter().filter(|coord| !territory.coords().contains(coord)).collect();
+            empty_intersections = empty_intersections.into_iter().filter(|coord| !territory.coords.contains(coord)).collect();
         }
-
         (black_score, white_score)
     }
 
-    fn build_territory_chain(&self, first_intersection: Coord) -> Chain {
-        let mut territory_chain = Chain::new(0, Empty);
+    fn build_territory_chain(&self, first_intersection: Coord) -> Territory {
+        let mut territory_chain = Territory::new();
         let mut to_visit = Vec::new();
         let mut neutral  = false;
 
@@ -486,11 +523,11 @@ impl<'a> Board<'a> {
 
         while to_visit.len() > 0 {
             let current_coord = to_visit.pop().unwrap();
-            if !territory_chain.coords().contains(&current_coord) {territory_chain.add_stone(current_coord);}
+            if !territory_chain.coords.contains(&current_coord) {territory_chain.coords.push(current_coord);}
 
             for &coord in self.neighbours(current_coord).iter() {
                 match self.color(coord) {
-                    Empty => if !territory_chain.coords().contains(&coord) {to_visit.push(coord)},
+                    Empty => if !territory_chain.coords.contains(&coord) {to_visit.push(coord)},
                     col   => if territory_chain.color != Empty && territory_chain.color != col {
                         neutral = true;
                     } else {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -140,7 +140,7 @@ impl<'a> Board<'a> {
         &self.neighbours[c]
     }
 
-    pub fn get_coord(&self, c: Coord) -> Color {
+    pub fn color(&self, c: Coord) -> Color {
         if c.is_inside(self.size) {
             self.get_chain(c).color
         } else {
@@ -212,7 +212,7 @@ impl<'a> Board<'a> {
 
         // We check if the new move is inside the board (and if it is, if there is no stone there)
         if m.coord().is_inside(self.size) {
-            if self.get_coord(m.coord()) != Empty {
+            if self.color(m.coord()) != Empty {
                 return Err(IllegalMove::IntersectionNotEmpty);
             }
         } else {
@@ -271,7 +271,7 @@ impl<'a> Board<'a> {
     fn find_neighbouring_friendly_chains_ids(&self, m: &Move) -> Vec<usize> {
         let mut friend_neigh_chains_id: Vec<usize> = self.neighbours(m.coord())
                   .iter()
-                  .filter(|&c| c.is_inside(self.size) && self.get_coord(*c) == *m.color())
+                  .filter(|&c| c.is_inside(self.size) && self.color(*c) == *m.color())
                   .map(|&c| self.get_chain(c).id)
                   .collect();
 
@@ -336,7 +336,7 @@ impl<'a> Board<'a> {
                                             .iter()
                                             .fold(Vec::new(), |mut acc, c| {
                                                 for &n in self.neighbours(*c).iter() {
-                                                    if n.is_inside(self.size) && self.get_coord(n) == Empty && !acc.contains(&n) {
+                                                    if n.is_inside(self.size) && self.color(n) == Empty && !acc.contains(&n) {
                                                         acc.push(n);
                                                     }
                                                 }
@@ -491,7 +491,7 @@ impl<'a> Board<'a> {
             if !territory_chain.coords().contains(&current_coord) {territory_chain.add_stone(current_coord);}
 
             for &coord in self.neighbours(current_coord).iter() {
-                match self.get_coord(coord) {
+                match self.color(coord) {
                     Empty => if !territory_chain.coords().contains(&coord) {to_visit.push(coord)},
                     col   => if territory_chain.color != Empty && territory_chain.color != col {
                         neutral = true;

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -357,14 +357,16 @@ impl<'a> Board<'a> {
         chain_ids.push(new_chain_id);
         let final_chain_id = chain_ids[0];
         let mut nb_removed_chains = 0;
-        for &other_chain_old_id in chain_ids.slice(1, chain_ids.len()).iter() {
-            let other_chain_id = other_chain_old_id - nb_removed_chains;
-            // We merge the other chain into the final chain.
-            let other_chain = self.chains[other_chain_id].clone();
-            self.chains[final_chain_id].merge(&other_chain);
-            // We remove the old chain.
-            self.move_stones_to_chain_and_remove(other_chain_id, final_chain_id);
-            nb_removed_chains += 1;
+        for &other_chain_old_id in chain_ids.iter() {
+            if other_chain_old_id != final_chain_id {
+                let other_chain_id = other_chain_old_id - nb_removed_chains;
+                // We merge the other chain into the final chain.
+                let other_chain = self.chains[other_chain_id].clone();
+                self.chains[final_chain_id].merge(&other_chain);
+                // We remove the old chain.
+                self.move_stones_to_chain_and_remove(other_chain_id, final_chain_id);
+                nb_removed_chains += 1;
+            }
         }
         // Removes the played stone from the liberty
         self.chains[final_chain_id].remove_liberty(m.coord());

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -42,7 +42,7 @@ mod ko;
 fn getting_a_valid_coord_returns_a_color() {
   let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  assert_eq!(b.get_coord(Coord::new(10, 10)), Empty);
+  assert_eq!(b.color(Coord::new(10, 10)), Empty);
 }
 
 #[test]
@@ -50,15 +50,15 @@ fn getting_a_valid_coord_returns_a_color() {
 fn getting_invalid_coordinates_fails() {
   let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  b.get_coord(Coord::new(14, 21));
-  b.get_coord(Coord::new(21, 14));
+  b.color(Coord::new(14, 21));
+  b.color(Coord::new(21, 14));
 }
 
 #[test]
 fn _19_19_is_a_valid_coordinate(){
   let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  assert_eq!(b.get_coord(Coord::new(19, 19)), Empty);
+  assert_eq!(b.color(Coord::new(19, 19)), Empty);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn _19_19_is_a_valid_coordinate(){
 fn _0_0_is_not_a_valid_coordinate(){
   let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  b.get_coord(Coord::new(0, 0));
+  b.color(Coord::new(0, 0));
 }
 
 #[test]
@@ -75,11 +75,11 @@ fn play_adds_a_stone_to_the_correct_position() {
 
     b = b.play(Play(Black, 14, 14)).unwrap();
 
-    assert!(b.get_coord(Coord::new(14, 14)) == Black);
+    assert!(b.color(Coord::new(14, 14)) == Black);
 
     for i in range(1u8, 20) {
         for j in range(1u8 , 20) {
-            assert!(b.get_coord(Coord::new(i, j)) == Empty || (i == 14 && j == 14));
+            assert!(b.color(Coord::new(i, j)) == Empty || (i == 14 && j == 14));
         }
     }
 }
@@ -165,9 +165,9 @@ fn playing_on_all_libs_in_corner_should_capture() {
   b = b.play(Play(White, 1, 2)).unwrap();
   b = b.play(Play(White, 2, 1)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(1, 1)), Empty);
-  assert_eq!(b.get_coord(Coord::new(1, 2)), White);
-  assert_eq!(b.get_coord(Coord::new(2, 1)), White);
+  assert_eq!(b.color(Coord::new(1, 1)), Empty);
+  assert_eq!(b.color(Coord::new(1, 2)), White);
+  assert_eq!(b.color(Coord::new(2, 1)), White);
 }
 
 #[test]
@@ -179,10 +179,10 @@ fn playing_on_all_libs_on_side_should_capture() {
   b = b.play(Play(White, 1, 4)).unwrap();
   b = b.play(Play(White, 2, 3)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(1, 3)), Empty);
-  assert_eq!(b.get_coord(Coord::new(1, 2)), White);
-  assert_eq!(b.get_coord(Coord::new(1, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(2, 3)), White);
+  assert_eq!(b.color(Coord::new(1, 3)), Empty);
+  assert_eq!(b.color(Coord::new(1, 2)), White);
+  assert_eq!(b.color(Coord::new(1, 4)), White);
+  assert_eq!(b.color(Coord::new(2, 3)), White);
 }
 
 #[test]
@@ -196,12 +196,12 @@ fn playing_on_all_libs_should_capture() {
   b = b.play(Play(White, 3, 4)).unwrap();
   b = b.play(Play(White, 5, 4)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(4, 4)), Empty);
+  assert_eq!(b.color(Coord::new(4, 4)), Empty);
 
-  assert_eq!(b.get_coord(Coord::new(4, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(5, 4)), White);
+  assert_eq!(b.color(Coord::new(4, 3)), White);
+  assert_eq!(b.color(Coord::new(4, 5)), White);
+  assert_eq!(b.color(Coord::new(3, 4)), White);
+  assert_eq!(b.color(Coord::new(5, 4)), White);
 }
 
 #[test]
@@ -218,15 +218,15 @@ fn playing_on_all_libs_of_a_chain_should_capture() {
   b = b.play(Play(White, 5, 5)).unwrap();
   b = b.play(Play(White, 4, 6)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(4, 4)), Empty);
-  assert_eq!(b.get_coord(Coord::new(4, 5)), Empty);
+  assert_eq!(b.color(Coord::new(4, 4)), Empty);
+  assert_eq!(b.color(Coord::new(4, 5)), Empty);
 
-  assert_eq!(b.get_coord(Coord::new(4, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(5, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(5, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 6)), White);
+  assert_eq!(b.color(Coord::new(4, 3)), White);
+  assert_eq!(b.color(Coord::new(3, 4)), White);
+  assert_eq!(b.color(Coord::new(5, 4)), White);
+  assert_eq!(b.color(Coord::new(3, 5)), White);
+  assert_eq!(b.color(Coord::new(5, 5)), White);
+  assert_eq!(b.color(Coord::new(4, 6)), White);
 }
 
 #[test]
@@ -245,17 +245,17 @@ fn playing_on_all_libs_of_a_bent_chain_should_capture() {
   b = b.play(Play(White, 5, 5)).unwrap();
   b = b.play(Play(White, 4, 6)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(4, 4)), Empty);
-  assert_eq!(b.get_coord(Coord::new(4, 5)), Empty);
-  assert_eq!(b.get_coord(Coord::new(3, 4)), Empty);
+  assert_eq!(b.color(Coord::new(4, 4)), Empty);
+  assert_eq!(b.color(Coord::new(4, 5)), Empty);
+  assert_eq!(b.color(Coord::new(3, 4)), Empty);
 
-  assert_eq!(b.get_coord(Coord::new(3, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(2, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(5, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(5, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 6)), White);
+  assert_eq!(b.color(Coord::new(3, 3)), White);
+  assert_eq!(b.color(Coord::new(4, 3)), White);
+  assert_eq!(b.color(Coord::new(2, 4)), White);
+  assert_eq!(b.color(Coord::new(5, 4)), White);
+  assert_eq!(b.color(Coord::new(3, 5)), White);
+  assert_eq!(b.color(Coord::new(5, 5)), White);
+  assert_eq!(b.color(Coord::new(4, 6)), White);
 }
 
 #[test]
@@ -316,15 +316,15 @@ fn suicide_should_remove_the_suicided_chain() {
 
   b = b.play(Play(Black, 3, 4)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(3, 4)), Empty);
-  assert_eq!(b.get_coord(Coord::new(4, 4)), Empty);
+  assert_eq!(b.color(Coord::new(3, 4)), Empty);
+  assert_eq!(b.color(Coord::new(4, 4)), Empty);
 
-  assert_eq!(b.get_coord(Coord::new(5, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 3)), White);
-  assert_eq!(b.get_coord(Coord::new(2, 4)), White);
-  assert_eq!(b.get_coord(Coord::new(4, 5)), White);
-  assert_eq!(b.get_coord(Coord::new(3, 5)), White);
+  assert_eq!(b.color(Coord::new(5, 4)), White);
+  assert_eq!(b.color(Coord::new(4, 3)), White);
+  assert_eq!(b.color(Coord::new(3, 3)), White);
+  assert_eq!(b.color(Coord::new(2, 4)), White);
+  assert_eq!(b.color(Coord::new(4, 5)), White);
+  assert_eq!(b.color(Coord::new(3, 5)), White);
 }
 
 #[test]
@@ -428,10 +428,10 @@ fn capturing_two_or_more_groups_while_playing_in_an_eye_actually_captures() {
   b = b.play(Play(Black, 5, 4)).unwrap();
   b = b.play(Play(White, 1, 1)).unwrap();
 
-  assert_eq!(b.get_coord(Coord::new(1, 1)), White);
-  assert_eq!(b.get_coord(Coord::new(1, 2)), Empty);
-  assert_eq!(b.get_coord(Coord::new(2, 1)), Empty);
-  assert_eq!(b.get_coord(Coord::new(2, 2)), White);
+  assert_eq!(b.color(Coord::new(1, 1)), White);
+  assert_eq!(b.color(Coord::new(1, 2)), Empty);
+  assert_eq!(b.color(Coord::new(2, 1)), Empty);
+  assert_eq!(b.color(Coord::new(2, 2)), White);
 }
 
 #[test]

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -102,19 +102,19 @@ fn playing_on_a_non_empty_intersection_should_return_error() {
 
 #[test]
 fn two_way_merging_works() {
-  let mut b = Board::new(19, 6.5, Minimal);
+    let mut b = Board::new(19, 6.5, Minimal);
 
-  b = b.play(Play(White, 10, 10)).unwrap();
-  b = b.play(Play(White, 10, 12)).unwrap();
+    b = b.play(Play(White, 10, 10)).unwrap();
+    b = b.play(Play(White, 10, 12)).unwrap();
 
-  assert_eq!(b.chains.len(), 3);
+    assert_eq!(b.chains.len(), 2);
 
-  b = b.play(Play(White, 10, 11)).unwrap();
-  let c_id = b.get_chain(Coord::new(10, 10)).id;
+    b = b.play(Play(White, 10, 11)).unwrap();
+    let c_id = b.get_chain(Coord::new(10, 10)).unwrap().id();
 
-  assert_eq!(b.get_chain(Coord::new(10, 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(10, 12)).id, c_id);
-  assert_eq!(b.chains.len(), 2)
+    assert_eq!(b.get_chain(Coord::new(10, 11)).unwrap().id(), c_id);
+    assert_eq!(b.get_chain(Coord::new(10, 12)).unwrap().id(), c_id);
+    assert_eq!(b.chains.len(), 1)
 }
 
 #[test]
@@ -125,15 +125,15 @@ fn three_way_merging_works() {
   b = b.play(Play(White, 11, 11)).unwrap();
   b = b.play(Play(White, 10, 12)).unwrap();
 
-  assert_eq!(b.chains.len(), 4);
+  assert_eq!(b.chains.len(), 3);
 
   b = b.play(Play(White, 10, 11)).unwrap();
-  let c_id = b.get_chain(Coord::new(10, 10)).id;
+  let c_id = b.get_chain(Coord::new(10, 10)).unwrap().id();
 
-  assert_eq!(b.get_chain(Coord::new(10, 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(11, 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(10, 12)).id, c_id);
-  assert_eq!(b.chains.len(), 2)
+  assert_eq!(b.get_chain(Coord::new(10, 11)).unwrap().id(), c_id);
+  assert_eq!(b.get_chain(Coord::new(11, 11)).unwrap().id(), c_id);
+  assert_eq!(b.get_chain(Coord::new(10, 12)).unwrap().id(), c_id);
+  assert_eq!(b.chains.len(), 1)
 }
 
 #[test]
@@ -145,16 +145,16 @@ fn four_way_merging_works() {
   b = b.play(Play(White, 11, 11)).unwrap();
   b = b.play(Play(White, 10, 12)).unwrap();
 
-  assert_eq!(b.chains.len(), 5);
+  assert_eq!(b.chains.len(), 4);
 
   b = b.play(Play(White, 10, 11)).unwrap();
-  let c_id = b.get_chain(Coord::new(10, 10)).id;
+  let c_id = b.get_chain(Coord::new(10, 10)).unwrap().id();
 
-  assert_eq!(b.get_chain(Coord::new(10, 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(9 , 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(11, 11)).id, c_id);
-  assert_eq!(b.get_chain(Coord::new(10, 12)).id, c_id);
-  assert_eq!(b.chains.len(), 2)
+  assert_eq!(b.get_chain(Coord::new(10, 11)).unwrap().id(), c_id);
+  assert_eq!(b.get_chain(Coord::new(9 , 11)).unwrap().id(), c_id);
+  assert_eq!(b.get_chain(Coord::new(11, 11)).unwrap().id(), c_id);
+  assert_eq!(b.get_chain(Coord::new(10, 12)).unwrap().id(), c_id);
+  assert_eq!(b.chains.len(), 1)
 }
 
 #[test]
@@ -369,30 +369,30 @@ fn counting_simple_case() {
 
 #[test]
 fn counting_disjoint_territory() {
-  let mut b = Board::new(5, 6.5, Minimal);
+    let mut b = Board::new(5, 6.5, Minimal);
 
-  b = b.play(Play(Black, 2, 1)).unwrap();
-  b = b.play(Play(White, 3, 1)).unwrap();
-  b = b.play(Play(Black, 2, 2)).unwrap();
-  b = b.play(Play(White, 3, 2)).unwrap();
-  b = b.play(Play(Black, 1, 3)).unwrap();
-  b = b.play(Play(White, 2, 3)).unwrap();
-  b = b.play(Play(Black, 5, 4)).unwrap();
-  b = b.play(Play(White, 1, 4)).unwrap();
-  b = b.play(Play(Black, 4, 4)).unwrap();
-  b = b.play(Play(White, 5, 3)).unwrap();
-  b = b.play(Play(Black, 4, 5)).unwrap();
-  b = b.play(Play(White, 4, 3)).unwrap();
-  b = b.play(Play(Black, 1, 2)).unwrap();
-  b = b.play(Play(White, 3, 4)).unwrap();
-  b = b.play(Pass(Black)).unwrap();
-  b = b.play(Play(White, 3, 5)).unwrap();
-  b = b.play(Pass(Black)).unwrap();
-  b = b.play(Pass(White)).unwrap();
+    b = b.play(Play(Black, 2, 1)).unwrap();
+    b = b.play(Play(White, 3, 1)).unwrap();
+    b = b.play(Play(Black, 2, 2)).unwrap();
+    b = b.play(Play(White, 3, 2)).unwrap();
+    b = b.play(Play(Black, 1, 3)).unwrap();
+    b = b.play(Play(White, 2, 3)).unwrap();
+    b = b.play(Play(Black, 5, 4)).unwrap();
+    b = b.play(Play(White, 1, 4)).unwrap();
+    b = b.play(Play(Black, 4, 4)).unwrap();
+    b = b.play(Play(White, 5, 3)).unwrap();
+    b = b.play(Play(Black, 4, 5)).unwrap();
+    b = b.play(Play(White, 4, 3)).unwrap();
+    b = b.play(Play(Black, 1, 2)).unwrap();
+    b = b.play(Play(White, 3, 4)).unwrap();
+    b = b.play(Pass(Black)).unwrap();
+    b = b.play(Play(White, 3, 5)).unwrap();
+    b = b.play(Pass(Black)).unwrap();
+    b = b.play(Pass(White)).unwrap();
 
-  let (b_score, w_score) = b.score_tt();
-  assert_eq!(b_score, 9);
-  assert_eq!(w_score, 16);
+    let (b_score, w_score) = b.score_tt();
+    assert_eq!(b_score, 9);
+    assert_eq!(w_score, 16);
 }
 
 #[test]
@@ -417,21 +417,21 @@ fn counting_with_neutral_points() {
 
 #[test]
 fn capturing_two_or_more_groups_while_playing_in_an_eye_actually_captures() {
-  let mut b = Board::new(5, 6.5, AnySizeTrompTaylor);
+    let mut b = Board::new(5, 6.5, AnySizeTrompTaylor);
 
-  b = b.play(Play(Black, 2, 1)).unwrap();
-  b = b.play(Play(White, 3, 1)).unwrap();
-  b = b.play(Play(Black, 1, 2)).unwrap();
-  b = b.play(Play(White, 2, 2)).unwrap();
-  b = b.play(Play(Black, 5, 5)).unwrap();
-  b = b.play(Play(White, 1, 3)).unwrap();
-  b = b.play(Play(Black, 5, 4)).unwrap();
-  b = b.play(Play(White, 1, 1)).unwrap();
+    b = b.play(Play(Black, 2, 1)).unwrap();
+    b = b.play(Play(White, 3, 1)).unwrap();
+    b = b.play(Play(Black, 1, 2)).unwrap();
+    b = b.play(Play(White, 2, 2)).unwrap();
+    b = b.play(Play(Black, 5, 5)).unwrap();
+    b = b.play(Play(White, 1, 3)).unwrap();
+    b = b.play(Play(Black, 5, 4)).unwrap();
+    b = b.play(Play(White, 1, 1)).unwrap();
 
-  assert_eq!(b.color(Coord::new(1, 1)), White);
-  assert_eq!(b.color(Coord::new(1, 2)), Empty);
-  assert_eq!(b.color(Coord::new(2, 1)), Empty);
-  assert_eq!(b.color(Coord::new(2, 2)), White);
+    assert_eq!(b.color(Coord::new(1, 1)), White);
+    assert_eq!(b.color(Coord::new(1, 2)), Empty);
+    assert_eq!(b.color(Coord::new(2, 1)), Empty);
+    assert_eq!(b.color(Coord::new(2, 2)), White);
 }
 
 #[test]
@@ -489,12 +489,6 @@ fn legal_moves_only_contains_legal_moves() {
 fn ruleset_returns_the_correct_ruleset() {
     let b = Board::new(1, 6.5, Minimal);
     assert_eq!(b.ruleset(), Minimal);
-}
-
-#[test]
-fn chains_returns_the_chains_on_the_board() {
-    let b = Board::new(1, 6.5, Minimal);
-    assert_eq!(*b.chains(), vec!(Chain::new(0, Empty)));
 }
 
 #[test]

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -96,7 +96,7 @@ impl<'a> Game<'a> {
     // Note: This method uses 1-1 as the origin point, not 0-0. 19-19 is a valid coordinate in a 19-sized board, while 0-0 is not.
     //       this is done because I think it makes more sense in the context of go. (Least surprise principle, etc...)
     pub fn get(&self, col: u8, row: u8) -> Color {
-        self.board.get_coord(Coord::new(col, row))
+        self.board.color(Coord::new(col, row))
     }
 
     pub fn ruleset(&self) -> Ruleset {
@@ -168,7 +168,7 @@ impl<'a> String for Game<'a> {
             for col in range(1u8, self.board.size()+1) {
                 let current_coords = Coord::new(col, row);
 
-                match self.board.get_coord(current_coords) {
+                match self.board.color(current_coords) {
                     Empty => {
                         let hoshis = &[4u8,10,16];
                         if  hoshis.contains(&row) && hoshis.contains(&col) {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -158,31 +158,7 @@ impl<'a> String for Game<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut s = format!("komi: {}\n", self.komi());
 
-        // First we print the board
-        for row in range(1u8, self.board.size()+1).rev() {
-
-            // Prints the row number
-            s.push_str(format!("{:2} ", row).as_slice());
-
-            // Prints the actual row
-            for col in range(1u8, self.board.size()+1) {
-                let current_coords = Coord::new(col, row);
-
-                match self.board.color(current_coords) {
-                    Empty => {
-                        let hoshis = &[4u8,10,16];
-                        if  hoshis.contains(&row) && hoshis.contains(&col) {
-                            s.push_str("+ ");
-                        } else {
-                            s.push_str(". ");
-                        }
-                    },
-                    White => { s.push_str("O "); },
-                    Black => { s.push_str("X "); }
-                }
-            }
-            s.push_str("\n");
-        }
+        s.push_str(self.board.as_string().as_slice());
 
         // Then we print the col numbers under the board
         s.push_str(format!("{:3}", "").as_slice());


### PR DESCRIPTION
This implements #68. Unfortunately it doesn't speed up the code, it even makes it slightly slower. Before we had 54pps for 9x9 and 11pps for 19x19. Now we have 50pps on 9x9 and 8pps on 19x19. But what this does is shift where the time is spent. Now, 97% of the time is spent in `Board.legal_moves()`. And 79% of the total time is spent in `Board.play()` within `Board.legal_moves()`. Now with the liberties in the chains it should be easily possible to implement #57 which (fingers crossed) should get us a big performance increase as we don't need to clone the board for the legality check anymore.