### PR TITLE
Store neighbours as a vector of vectors #53

### DIFF
--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -39,7 +39,7 @@ impl Coord {
         let mut coords = Vec::new();
         for i in range(0, size) {
             for j in range(0, size) {
-                coords.push(Coord::new(i+1, j+1));
+                coords.push(Coord::new(j+1, i+1));
             }
         }
         coords

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -99,7 +99,7 @@ pub struct Board<'a> {
     friend_stones_removed: Vec<Coord>,
     ko:                    Option<Coord>,
     komi:                  f32,
-    neighbours:            Rc<HashMap<Coord, Vec<Coord>>>,
+    neighbours:            Rc<Vec<Vec<Coord>>>,
     previous_player:       Color,
     ruleset:               Ruleset,
     size:                  u8,
@@ -140,16 +140,16 @@ impl<'a> Board<'a> {
         }
     }
 
-    fn setup_neighbours(size: u8) -> Rc<HashMap<Coord, Vec<Coord>>> {
-        let mut neighbours = HashMap::new();
+    fn setup_neighbours(size: u8) -> Rc<Vec<Vec<Coord>>> {
+        let mut neighbours = Vec::new();
         for coord in Coord::for_board_size(size).iter() {
-            neighbours.insert(*coord, coord.neighbours(size));
+            neighbours.push(coord.neighbours(size));
         }
         Rc::new(neighbours)
     }
 
     fn neighbours(&self, c: Coord) -> &Vec<Coord> {
-        &self.neighbours[c]
+        &self.neighbours[c.to_index(self.size)]
     }
 
     pub fn color(&self, c: Coord) -> Color {


### PR DESCRIPTION
As we only ever setup the neighbours once and only iterate over all neighbours using a Vec instead of a HashMap is much quicker.

This one change gets us from 1296pps on to 2130pps on 9x9 and from 522pps to 1160pps on 19x19.
