### PR TITLE
Fixed a bug where the computation of win ratio would be 100% for new pass move

### DIFF
--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -60,7 +60,11 @@ impl MoveStats {
     }
 
     pub fn win_ratio(&self) -> f32 {
-        (self.wins as f32) / (self.plays as f32)
+        if self.plays == 0 {
+            0f32
+        } else {
+            (self.wins as f32) / (self.plays as f32)
+        }
     }
 }
 
@@ -81,8 +85,7 @@ impl Engine for McEngine {
             stats.insert(m, MoveStats::new());
         }
         for m in moves.iter() {
-            // We use 1 here right now, as it's so damn slow.
-            for _ in range(0us, 1) {
+            for _ in range(0us, 1000) {
                 let g = game.play(*m).unwrap();
                 let playout = Playout::new(g.board());
                 let winner = playout.run();

--- a/src/engine/mc/test.rs
+++ b/src/engine/mc/test.rs
@@ -25,7 +25,7 @@ use board::Black;
 use engine::Engine;
 use game::Game;
 use ruleset::KgsChinese;
-use super::McEngine;
+use super::{McEngine, MoveStats};
 
 use test::Bencher;
 
@@ -36,6 +36,12 @@ fn produces_a_move() {
     let color  = Black;
     let m      = engine.gen_move(color, &game);
     assert_eq!(Black, *m.color());
+}
+
+#[test]
+fn newly_produced_move_stats_should_have_0pc_win_ratio() {
+  let ms = MoveStats::new();
+  assert_eq!(ms.win_ratio(), 0f32);
 }
 
 #[bench]


### PR DESCRIPTION
This allows the MC Engine to actually play.

I've also bumped up the number of playouts/move to 1000 to reflect our gain in speed. On my machine, this give a playable 9x9, with some okayish moves generated (captures seen, etc...).