### PR TITLE
Further playout speed ups

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -514,17 +514,7 @@ impl<'a> Board<'a> {
                 None => {}
             }
         }
-        let mut empty_intersections = Vec::<Coord>::new();
-        for i in range(0, self.board.len()) {
-            let possible_chain_id = self.board[i];
-            match possible_chain_id {
-                None => {
-                    let c = Coord::from_index(i, self.size);
-                    empty_intersections.push(c);
-                },
-                Some(_) => {}
-            }
-        }
+        let mut empty_intersections = self.vacant.clone();
         while empty_intersections.len() > 0 {
             let territory = self.build_territory_chain(empty_intersections[0]);
 

--- a/src/board/point/mod.rs
+++ b/src/board/point/mod.rs
@@ -1,0 +1,36 @@
+/************************************************************************
+ *                                                                      *
+ * Copyright 2015 Urban Hafner                                          *
+ *                                                                      *
+ * This file is part of Iomrascálaí.                                    *
+ *                                                                      *
+ * Iomrascálaí is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by *
+ * the Free Software Foundation, either version 3 of the License, or    *
+ * (at your option) any later version.                                  *
+ *                                                                      *
+ * Iomrascálaí is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ * GNU General Public License for more details.                         *
+ *                                                                      *
+ * You should have received a copy of the GNU General Public License    *
+ * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
+ *                                                                      *
+ ************************************************************************/
+
+use super::Color;
+use super::Empty;
+
+#[derive(Clone, Show)]
+pub struct Point {
+    pub chain_id: usize,
+    pub color: Color,
+}
+
+impl Point {
+
+    pub fn new() -> Point {
+        Point { chain_id: 0, color: Empty }
+    }
+}

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -40,33 +40,33 @@ mod ko;
 
 #[test]
 fn getting_a_valid_coord_returns_a_color() {
-  let b = Board::new(19, 6.5, AnySizeTrompTaylor);
+    let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  assert_eq!(b.color(Coord::new(10, 10)), Empty);
+    assert_eq!(b.color(&Coord::new(10, 10)), Empty);
 }
 
 #[test]
 #[should_fail]
 fn getting_invalid_coordinates_fails() {
-  let b = Board::new(19, 6.5, AnySizeTrompTaylor);
+    let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  b.color(Coord::new(14, 21));
-  b.color(Coord::new(21, 14));
+    b.color(&Coord::new(14, 21));
+    b.color(&Coord::new(21, 14));
 }
 
 #[test]
 fn _19_19_is_a_valid_coordinate(){
-  let b = Board::new(19, 6.5, AnySizeTrompTaylor);
+    let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  assert_eq!(b.color(Coord::new(19, 19)), Empty);
+    assert_eq!(b.color(&Coord::new(19, 19)), Empty);
 }
 
 #[test]
 #[should_fail]
 fn _0_0_is_not_a_valid_coordinate(){
-  let b = Board::new(19, 6.5, AnySizeTrompTaylor);
+    let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
-  b.color(Coord::new(0, 0));
+    b.color(&Coord::new(0, 0));
 }
 
 #[test]
@@ -75,11 +75,11 @@ fn play_adds_a_stone_to_the_correct_position() {
 
     b.play(Play(Black, 14, 14));
 
-    assert!(b.color(Coord::new(14, 14)) == Black);
+    assert!(b.color(&Coord::new(14, 14)) == Black);
 
     for i in range(1u8, 20) {
         for j in range(1u8 , 20) {
-            assert!(b.color(Coord::new(i, j)) == Empty || (i == 14 && j == 14));
+            assert!(b.color(&Coord::new(i, j)) == Empty || (i == 14 && j == 14));
         }
     }
 }
@@ -139,7 +139,6 @@ fn three_way_merging_works() {
 #[test]
 fn four_way_merging_works() {
     let mut b = Board::new(19, 6.5, Minimal);
-
     b.play(Play(White, 10, 10));
     b.play(Play(White, 9, 11));
     b.play(Play(White, 11, 11));
@@ -165,9 +164,9 @@ fn playing_on_all_libs_in_corner_should_capture() {
     b.play(Play(White, 1, 2));
     b.play(Play(White, 2, 1));
 
-    assert_eq!(b.color(Coord::new(1, 1)), Empty);
-    assert_eq!(b.color(Coord::new(1, 2)), White);
-    assert_eq!(b.color(Coord::new(2, 1)), White);
+    assert_eq!(b.color(&Coord::new(1, 1)), Empty);
+    assert_eq!(b.color(&Coord::new(1, 2)), White);
+    assert_eq!(b.color(&Coord::new(2, 1)), White);
 }
 
 #[test]
@@ -179,10 +178,10 @@ fn playing_on_all_libs_on_side_should_capture() {
     b.play(Play(White, 1, 4));
     b.play(Play(White, 2, 3));
 
-    assert_eq!(b.color(Coord::new(1, 3)), Empty);
-    assert_eq!(b.color(Coord::new(1, 2)), White);
-    assert_eq!(b.color(Coord::new(1, 4)), White);
-    assert_eq!(b.color(Coord::new(2, 3)), White);
+    assert_eq!(b.color(&Coord::new(1, 3)), Empty);
+    assert_eq!(b.color(&Coord::new(1, 2)), White);
+    assert_eq!(b.color(&Coord::new(1, 4)), White);
+    assert_eq!(b.color(&Coord::new(2, 3)), White);
 }
 
 #[test]
@@ -196,12 +195,12 @@ fn playing_on_all_libs_should_capture() {
     b.play(Play(White, 3, 4));
     b.play(Play(White, 5, 4));
 
-    assert_eq!(b.color(Coord::new(4, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 4)), Empty);
 
-    assert_eq!(b.color(Coord::new(4, 3)), White);
-    assert_eq!(b.color(Coord::new(4, 5)), White);
-    assert_eq!(b.color(Coord::new(3, 4)), White);
-    assert_eq!(b.color(Coord::new(5, 4)), White);
+    assert_eq!(b.color(&Coord::new(4, 3)), White);
+    assert_eq!(b.color(&Coord::new(4, 5)), White);
+    assert_eq!(b.color(&Coord::new(3, 4)), White);
+    assert_eq!(b.color(&Coord::new(5, 4)), White);
 }
 
 #[test]
@@ -218,15 +217,15 @@ fn playing_on_all_libs_of_a_chain_should_capture() {
     b.play(Play(White, 5, 5));
     b.play(Play(White, 4, 6));
 
-    assert_eq!(b.color(Coord::new(4, 4)), Empty);
-    assert_eq!(b.color(Coord::new(4, 5)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 5)), Empty);
 
-    assert_eq!(b.color(Coord::new(4, 3)), White);
-    assert_eq!(b.color(Coord::new(3, 4)), White);
-    assert_eq!(b.color(Coord::new(5, 4)), White);
-    assert_eq!(b.color(Coord::new(3, 5)), White);
-    assert_eq!(b.color(Coord::new(5, 5)), White);
-    assert_eq!(b.color(Coord::new(4, 6)), White);
+    assert_eq!(b.color(&Coord::new(4, 3)), White);
+    assert_eq!(b.color(&Coord::new(3, 4)), White);
+    assert_eq!(b.color(&Coord::new(5, 4)), White);
+    assert_eq!(b.color(&Coord::new(3, 5)), White);
+    assert_eq!(b.color(&Coord::new(5, 5)), White);
+    assert_eq!(b.color(&Coord::new(4, 6)), White);
 }
 
 #[test]
@@ -245,17 +244,17 @@ fn playing_on_all_libs_of_a_bent_chain_should_capture() {
     b.play(Play(White, 5, 5));
     b.play(Play(White, 4, 6));
 
-    assert_eq!(b.color(Coord::new(4, 4)), Empty);
-    assert_eq!(b.color(Coord::new(4, 5)), Empty);
-    assert_eq!(b.color(Coord::new(3, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 5)), Empty);
+    assert_eq!(b.color(&Coord::new(3, 4)), Empty);
 
-    assert_eq!(b.color(Coord::new(3, 3)), White);
-    assert_eq!(b.color(Coord::new(4, 3)), White);
-    assert_eq!(b.color(Coord::new(2, 4)), White);
-    assert_eq!(b.color(Coord::new(5, 4)), White);
-    assert_eq!(b.color(Coord::new(3, 5)), White);
-    assert_eq!(b.color(Coord::new(5, 5)), White);
-    assert_eq!(b.color(Coord::new(4, 6)), White);
+    assert_eq!(b.color(&Coord::new(3, 3)), White);
+    assert_eq!(b.color(&Coord::new(4, 3)), White);
+    assert_eq!(b.color(&Coord::new(2, 4)), White);
+    assert_eq!(b.color(&Coord::new(5, 4)), White);
+    assert_eq!(b.color(&Coord::new(3, 5)), White);
+    assert_eq!(b.color(&Coord::new(5, 5)), White);
+    assert_eq!(b.color(&Coord::new(4, 6)), White);
 }
 
 #[test]
@@ -316,15 +315,15 @@ fn suicide_should_remove_the_suicided_chain() {
 
     b.play(Play(Black, 3, 4));
 
-    assert_eq!(b.color(Coord::new(3, 4)), Empty);
-    assert_eq!(b.color(Coord::new(4, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(3, 4)), Empty);
+    assert_eq!(b.color(&Coord::new(4, 4)), Empty);
 
-    assert_eq!(b.color(Coord::new(5, 4)), White);
-    assert_eq!(b.color(Coord::new(4, 3)), White);
-    assert_eq!(b.color(Coord::new(3, 3)), White);
-    assert_eq!(b.color(Coord::new(2, 4)), White);
-    assert_eq!(b.color(Coord::new(4, 5)), White);
-    assert_eq!(b.color(Coord::new(3, 5)), White);
+    assert_eq!(b.color(&Coord::new(5, 4)), White);
+    assert_eq!(b.color(&Coord::new(4, 3)), White);
+    assert_eq!(b.color(&Coord::new(3, 3)), White);
+    assert_eq!(b.color(&Coord::new(2, 4)), White);
+    assert_eq!(b.color(&Coord::new(4, 5)), White);
+    assert_eq!(b.color(&Coord::new(3, 5)), White);
 }
 
 #[test]
@@ -428,10 +427,10 @@ fn capturing_two_or_more_groups_while_playing_in_an_eye_actually_captures() {
     b.play(Play(Black, 5, 4));
     b.play(Play(White, 1, 1));
 
-    assert_eq!(b.color(Coord::new(1, 1)), White);
-    assert_eq!(b.color(Coord::new(1, 2)), Empty);
-    assert_eq!(b.color(Coord::new(2, 1)), Empty);
-    assert_eq!(b.color(Coord::new(2, 2)), White);
+    assert_eq!(b.color(&Coord::new(1, 1)), White);
+    assert_eq!(b.color(&Coord::new(1, 2)), Empty);
+    assert_eq!(b.color(&Coord::new(2, 1)), Empty);
+    assert_eq!(b.color(&Coord::new(2, 2)), White);
 }
 
 #[test]

--- a/src/engine/mc/test.rs
+++ b/src/engine/mc/test.rs
@@ -34,11 +34,3 @@ fn newly_produced_move_stats_should_have_0pc_win_ratio() {
   let ms = MoveStats::new();
   assert_eq!(ms.win_ratio(), 0f32);
 }
-
-#[bench]
-fn bench_engine_move_generation(b: &mut Bencher) {
-    let engine = McEngine::new();
-    let game   = Game::new(5, 6.5, KgsChinese);
-    let color  = Black;
-    b.iter(|| {engine.gen_move(color, &game)})
-}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -96,7 +96,7 @@ impl<'a> Game<'a> {
     // Note: This method uses 1-1 as the origin point, not 0-0. 19-19 is a valid coordinate in a 19-sized board, while 0-0 is not.
     //       this is done because I think it makes more sense in the context of go. (Least surprise principle, etc...)
     pub fn get(&self, col: u8, row: u8) -> Color {
-        self.board.color(Coord::new(col, row))
+        self.board.color(&Coord::new(col, row))
     }
 
     pub fn ruleset(&self) -> Ruleset {


### PR DESCRIPTION
Adds a vector of vacant point to the `Board` to speed up `legal_moves()`. Also changes the `board` Vec to contain both the color and chain id to speed up finding neighbours of a certain color.

This improves the playout speed on 9x9 from 1800pps to 2300pps and on 19x19 from 1000pps to 1300pps. That's nice, but [we still have a long way to go](http://computer-go.org/pipermail/computer-go/2015-January/007185.html).