### PR TITLE
13x13 benchmark

### DIFF
--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -34,6 +34,15 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_13x13_playout_speed(b: &mut Bencher) {
+    let game = Game::new(13, 6.5, KgsChinese);
+    let board = game.board();
+    let playout_engine = Playout::new(board);
+
+    b.iter(|| {playout_engine.run()})
+}
+
+#[bench]
 fn bench_19x19_playout_speed(b: &mut Bencher) {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();


### PR DESCRIPTION
We already have benchmarks for 9x9 and 19x19, but as 13x13 is a common size (at least in computer games) we should have one for it, too.