### PR TITLE
Make sure Game.legal_moves() excludes super ko moves

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -194,7 +194,7 @@ impl<'a> Board<'a> {
         &self.friend_stones_removed
     }
 
-    pub fn legal_moves(&self) -> Vec<Move> {
+    pub fn legal_moves_without_superko_check(&self) -> Vec<Move> {
         let color = self.next_player();
         let mut moves : Vec<Move> = self.vacant
             .iter()

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -381,14 +381,14 @@ fn next_player_should_return_white_after_a_single_move() {
 #[test]
 fn legal_moves_should_include_pass() {
     let b = Board::new(5, 6.5, AnySizeTrompTaylor);
-    let moves = b.legal_moves();
+    let moves = b.legal_moves_without_superko_check();
     assert!(moves.contains(&Pass(Black)));
 }
 
 #[test]
 fn legal_moves_should_return_black_moves_on_a_board_without_moves() {
     let b = Board::new(5, 6.5, AnySizeTrompTaylor);
-    let moves = b.legal_moves();
+    let moves = b.legal_moves_without_superko_check();
     let all_black = moves.iter().all(|m| m.color() == &Black);
     assert!(all_black);
 }
@@ -397,7 +397,7 @@ fn legal_moves_should_return_black_moves_on_a_board_without_moves() {
 fn legal_moves_should_return_white_moves_on_a_board_with_one_move() {
     let mut b = Board::new(5, 6.5, AnySizeTrompTaylor);
     b.play(Play(Black, 1, 1));
-    let moves = b.legal_moves();
+    let moves = b.legal_moves_without_superko_check();
     let all_white = moves.iter().all(|m| m.color() == &White);
     assert!(all_white);
 }
@@ -405,14 +405,14 @@ fn legal_moves_should_return_white_moves_on_a_board_with_one_move() {
 #[test]
 fn legal_moves_contains_the_right_number_of_moves_for_an_empty_board() {
     let b = Board::new(5, 6.5, AnySizeTrompTaylor);
-    assert_eq!(b.legal_moves().len(), 25+1);
+    assert_eq!(b.legal_moves_without_superko_check().len(), 25+1);
 }
 
 #[test]
 fn legal_moves_only_contains_legal_moves() {
     let mut b = Board::new(5, 6.5, AnySizeTrompTaylor);
     b.play(Play(Black, 1, 1));
-    let moves = b.legal_moves();
+    let moves = b.legal_moves_without_superko_check();
     assert!(!moves.iter().any(|m| m == &Play(White, 1, 1)));
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -151,7 +151,7 @@ impl<'a> Game<'a> {
 
     pub fn legal_moves(&self) -> Vec<Move> {
         self.board
-            .legal_moves()
+            .legal_moves_without_superko_check()
             .into_iter()
             .filter(|&m| self.play(m).is_ok())
             .collect()

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -150,7 +150,11 @@ impl<'a> Game<'a> {
     }
 
     pub fn legal_moves(&self) -> Vec<Move> {
-        self.board.legal_moves()
+        self.board
+            .legal_moves()
+            .into_iter()
+            .filter(|&m| self.play(m).is_ok())
+            .collect()
     }
 }
 

--- a/src/game/test/ko.rs
+++ b/src/game/test/ko.rs
@@ -60,3 +60,11 @@ fn positional_super_ko_should_be_illegal() {
         Ok(_)  => panic!("expected Err")
     }
 }
+
+#[test]
+fn legal_moves_shouldnt_contain_super_ko_moves() {
+    let parser   = Parser::from_path(Path::new("fixtures/sgf/positional-superko.sgf"));
+    let game     = parser.game().unwrap();
+    let super_ko = Play(White, 2, 9);
+    assert!(!game.legal_moves().contains(&super_ko), "super ko move found");
+}

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -39,7 +39,7 @@ impl<'a> Playout<'a> {
         let max_moves = board.size() * board.size() * 3;
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
-            let moves = board.legal_moves();
+            let moves = board.legal_moves_without_superko_check();
             let m = moves[random::<usize>() % moves.len()];
             board.play(m);
             move_count += 1;


### PR DESCRIPTION
Before this, `Game.legal_moves()` included moves that violated the super ko rule and therefore the `McEngine` generated illegal moves, which crashed the bot.