### PR TITLE
Don't play in single point eyes

### DIFF
--- a/fixtures/sgf/eye/corner-no-enemies.sgf
+++ b/fixtures/sgf/eye/corner-no-enemies.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ba][ab])

--- a/fixtures/sgf/eye/corner-not-an-eye.sgf
+++ b/fixtures/sgf/eye/corner-not-an-eye.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ba]AW[ab])

--- a/fixtures/sgf/eye/corner-one-enemy.sgf
+++ b/fixtures/sgf/eye/corner-one-enemy.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ba][ab]AW[bb])

--- a/fixtures/sgf/eye/edge-no-enemies.sgf
+++ b/fixtures/sgf/eye/edge-no-enemies.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ab][bc][ad])

--- a/fixtures/sgf/eye/edge-not-an-eye.sgf
+++ b/fixtures/sgf/eye/edge-not-an-eye.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ab][ad]AW[bc])

--- a/fixtures/sgf/eye/edge-one-enemy.sgf
+++ b/fixtures/sgf/eye/edge-one-enemy.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[ab][bc][ad]AW[bb])

--- a/fixtures/sgf/eye/no-enemies.sgf
+++ b/fixtures/sgf/eye/no-enemies.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[cb][bc][cd][dc])

--- a/fixtures/sgf/eye/not-an-eye.sgf
+++ b/fixtures/sgf/eye/not-an-eye.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[cb][bc][cd]AW[dc])

--- a/fixtures/sgf/eye/one-enemy.sgf
+++ b/fixtures/sgf/eye/one-enemy.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[cb][bc][cd][dc]AW[db])

--- a/fixtures/sgf/eye/two-enemies.sgf
+++ b/fixtures/sgf/eye/two-enemies.sgf
@@ -1,0 +1,3 @@
+(;FF[4]CA[UTF-8]AP[GoGui:1.4.9]SZ[5]
+KM[6.5]DT[2015-01-16]
+AB[cb][bc][cd][dc]AW[db][bb])

--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -65,8 +65,15 @@ impl Coord {
     }
 
     pub fn orthogonals(&self, board_size: u8) -> Vec<Coord> {
-        // TODO: Implement!
-        Vec::new()
+        vec!(
+            Coord::new(self.col-1, self.row-1),
+            Coord::new(self.col+1, self.row-1),
+            Coord::new(self.col+1, self.row+1),
+            Coord::new(self.col-1, self.row+1)
+                ).iter()
+            .filter(|c| c.is_inside(board_size))
+            .cloned()
+            .collect()
     }
 
     pub fn to_index(&self, board_size: u8) -> usize {

--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -64,6 +64,11 @@ impl Coord {
         neighbours
     }
 
+    pub fn orthogonals(&self, board_size: u8) -> Vec<Coord> {
+        // TODO: Implement!
+        Vec::new()
+    }
+
     pub fn to_index(&self, board_size: u8) -> usize {
         (self.col as usize-1 + (self.row as usize-1)*board_size as usize)
     }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -211,7 +211,17 @@ impl Board {
     }
 
     pub fn is_eye(&self, coord: &Coord, color: Color) -> bool {
-        true
+        let neighbours = self.neighbours(*coord);
+        if neighbours.iter().all(|c| self.color(c) == color) {
+            let orthogonals = self.orthogonals(*coord);
+            if orthogonals.len() < 4 {
+                orthogonals.iter().all(|c| self.color(c) != color.opposite())
+            } else {
+                orthogonals.iter().filter(|c| self.color(c) == color.opposite()).count() <= 1
+            }
+        } else {
+            false
+        }
     }
 
     fn is_same_player(&self, m: &Move) -> bool {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -250,6 +250,13 @@ impl Board {
         }
     }
 
+    pub fn legal_moves_without_eyes(&self) -> Vec<Move> {
+        self.legal_moves_without_superko_check()
+            .into_iter()
+            .filter(|m| m.is_pass() || !self.is_eye(&m.coord(), *m.color()))
+            .collect()
+    }
+
     pub fn is_legal(&self, m: Move) -> Result<(), IllegalMove> {
         // Can't play if the game is already over
         if self.is_game_over() && !self.ruleset.game_over_play() {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -100,6 +100,7 @@ pub struct Board {
     ko:                    Option<Coord>,
     komi:                  f32,
     neighbours:            Rc<Vec<Vec<Coord>>>,
+    orthogonals:           Rc<Vec<Vec<Coord>>>,
     previous_player:       Color,
     resigned_by:           Color,
     ruleset:               Ruleset,
@@ -118,6 +119,7 @@ impl Clone for Board {
             ko:                    self.ko,
             komi:                  self.komi,
             neighbours:            self.neighbours.clone(),
+            orthogonals:           self.orthogonals.clone(),
             previous_player:       self.previous_player,
             resigned_by:           self.resigned_by,
             ruleset:               self.ruleset.clone(),
@@ -138,6 +140,7 @@ impl Board {
             ko:                    None,
             komi:                  komi,
             neighbours:            Board::setup_neighbours(size),
+            orthogonals:           Board::setup_orthogonals(size),
             previous_player:       White,
             resigned_by:           Empty,
             ruleset:               ruleset,
@@ -154,8 +157,20 @@ impl Board {
         Rc::new(neighbours)
     }
 
+    fn setup_orthogonals(size: u8) -> Rc<Vec<Vec<Coord>>> {
+        let mut orthogonals = Vec::new();
+        for coord in Coord::for_board_size(size).iter() {
+            orthogonals.push(coord.orthogonals(size));
+        }
+        Rc::new(orthogonals)
+    }
+
     pub fn neighbours(&self, c: Coord) -> &Vec<Coord> {
         &self.neighbours[c.to_index(self.size)]
+    }
+
+    pub fn orthogonals(&self, c: Coord) -> &Vec<Coord> {
+        &self.orthogonals[c.to_index(self.size)]
     }
 
     pub fn points(&self) -> &Vec<Point> {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -195,6 +195,10 @@ impl Board {
         self.previous_player.opposite()
     }
 
+    pub fn is_eye(&self, coord: &Coord, color: Color) -> bool {
+        true
+    }
+
     fn is_same_player(&self, m: &Move) -> bool {
         self.previous_player == *m.color()
     }

--- a/src/board/test/eye.rs
+++ b/src/board/test/eye.rs
@@ -23,6 +23,8 @@
 
 use board::Black;
 use board::Coord;
+use board::Pass;
+use board::White;
 use sgf::Parser;
 
 #[test]
@@ -103,4 +105,14 @@ fn two_enemies_is_not_an_eye() {
     let game   = parser.game().unwrap();
     let board  = game.board();
     assert_eq!(false, board.is_eye(&Coord::new(3,3), Black));
+}
+
+#[test]
+fn legal_moves_without_eyes_shouldnt_include_an_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/no-enemies.sgf"));
+    let game   = parser.game().unwrap();
+    let mut board  = game.board();
+    board.play(Pass(White));
+    let moves  = board.legal_moves_without_eyes();
+    assert!(!moves.iter().any(|m| !m.is_pass() && m.coord() == Coord::new(3, 3)));
 }

--- a/src/board/test/eye.rs
+++ b/src/board/test/eye.rs
@@ -1,0 +1,106 @@
+/************************************************************************
+ *                                                                      *
+ * Copyright 2015 Urban Hafner                                          *
+ *                                                                      *
+ * This file is part of Iomrascálaí.                                    *
+ *                                                                      *
+ * Iomrascálaí is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by *
+ * the Free Software Foundation, either version 3 of the License, or    *
+ * (at your option) any later version.                                  *
+ *                                                                      *
+ * Iomrascálaí is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ * GNU General Public License for more details.                         *
+ *                                                                      *
+ * You should have received a copy of the GNU General Public License    *
+ * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
+ *                                                                      *
+ ************************************************************************/
+
+#![cfg(test)]
+
+use board::Black;
+use board::Coord;
+use sgf::Parser;
+
+#[test]
+fn corner_no_enemies_is_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/corner-no-enemies.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(true, board.is_eye(&Coord::new(1,5), Black));
+}
+
+#[test]
+fn corner_not_an_eye_is_no_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/corner-not-an-eye.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(1,5), Black));
+}
+
+#[test]
+fn corner_one_enemy_is_no_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/corner-one-enemy.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(1,5), Black));
+}
+
+#[test]
+fn edge_no_enemies_is_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/edge-no-enemies.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(true, board.is_eye(&Coord::new(1,3), Black));
+}
+
+#[test]
+fn edge_not_an_eye_is_no_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/edge-not-an-eye.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(1,3), Black));
+}
+
+#[test]
+fn edge_one_enemy_is_no_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/edge-one-enemy.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(1,3), Black));
+}
+
+#[test]
+fn no_enemies_is_an_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/no-enemies.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(true, board.is_eye(&Coord::new(3,3), Black));
+}
+
+#[test]
+fn not_an_eye_is_no_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/not-an-eye.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(3,3), Black));
+}
+
+#[test]
+fn one_enemy_is_an_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/one-enemy.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(true, board.is_eye(&Coord::new(3,3), Black));
+}
+
+#[test]
+fn two_enemies_is_not_an_eye() {
+    let parser = Parser::from_path(Path::new("fixtures/sgf/eye/two-enemies.sgf"));
+    let game   = parser.game().unwrap();
+    let board  = game.board();
+    assert_eq!(false, board.is_eye(&Coord::new(3,3), Black));
+}

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -39,6 +39,7 @@ use test::Bencher;
 
 mod eye;
 mod ko;
+mod orthogonals;
 
 #[test]
 fn getting_a_valid_coord_returns_a_color() {

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -143,6 +143,16 @@ fn legal_moves_should_return_nothing_after_a_resign() {
 }
 
 #[test]
+fn legal_moves_without_eyes_should_return_nothing_after_a_resing() {
+    let mut b = Board::new(9, 6.5, Minimal);
+
+    b.play(Resign(Black));
+
+    assert_eq!(vec!(), b.legal_moves_without_eyes());
+}
+
+
+#[test]
 fn two_way_merging_works() {
     let mut b = Board::new(19, 6.5, Minimal);
 

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -37,6 +37,7 @@ use ruleset::Minimal;
 
 use test::Bencher;
 
+mod eye;
 mod ko;
 
 #[test]

--- a/src/board/test/orthogonals.rs
+++ b/src/board/test/orthogonals.rs
@@ -1,0 +1,105 @@
+/************************************************************************
+ *                                                                      *
+ * Copyright 2015 Urban Hafner                                          *
+ *                                                                      *
+ * This file is part of Iomrascálaí.                                    *
+ *                                                                      *
+ * Iomrascálaí is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by *
+ * the Free Software Foundation, either version 3 of the License, or    *
+ * (at your option) any later version.                                  *
+ *                                                                      *
+ * Iomrascálaí is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ * GNU General Public License for more details.                         *
+ *                                                                      *
+ * You should have received a copy of the GNU General Public License    *
+ * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
+ *                                                                      *
+ ************************************************************************/
+
+#![cfg(test)]
+
+use board::Board;
+use board::Coord;
+use ruleset::Minimal;
+
+#[test]
+fn center_has_4_orthogonal_neighbours() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(2, 2));
+    assert_eq!(4, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(1, 1)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(1, 3)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 1)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 3)).is_some());
+}
+
+#[test]
+fn sw_has_1_orthogonal_neighbour() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(1, 1));
+    assert_eq!(1, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 2)).is_some());
+}
+
+#[test]
+fn s_has_2_orthogonal_neighbours() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(2, 1));
+    assert_eq!(2, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(1, 2)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 2)).is_some());
+}
+
+#[test]
+fn se_has_1_orthogonal_neighbour() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(3, 1));
+    assert_eq!(1, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 2)).is_some());
+}
+
+#[test]
+fn w_has_2_orthogonal_neighbours() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(1, 2));
+    assert_eq!(2, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 1)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 3)).is_some());
+}
+
+#[test]
+fn e_has_2_orthogonal_neighbours() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(3, 2));
+    assert_eq!(2, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 1)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 3)).is_some());
+}
+
+#[test]
+fn nw_has_1_orthogonal_neighbour() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(1, 3));
+    assert_eq!(1, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 2)).is_some());
+}
+
+#[test]
+fn n_has_2_orthogonal_neighbours() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(2, 3));
+    assert_eq!(2, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(1, 2)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 1)).is_some());
+}
+
+#[test]
+fn ne_has_1_orthogonal_neighbour() {
+    let b = Board::new(3, 6.5, Minimal);
+    let orthogonals = b.orthogonals(Coord::new(3, 3));
+    assert_eq!(1, orthogonals.len());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(2, 2)).is_some());
+}

--- a/src/board/test/orthogonals.rs
+++ b/src/board/test/orthogonals.rs
@@ -93,7 +93,7 @@ fn n_has_2_orthogonal_neighbours() {
     let orthogonals = b.orthogonals(Coord::new(2, 3));
     assert_eq!(2, orthogonals.len());
     assert!(orthogonals.iter().find(|&c| *c == Coord::new(1, 2)).is_some());
-    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 1)).is_some());
+    assert!(orthogonals.iter().find(|&c| *c == Coord::new(3, 2)).is_some());
 }
 
 #[test]

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -27,49 +27,11 @@ use board::Resign;
 use game::Game;
 use playout::Playout;
 use super::Engine;
+use super::MoveStats;
 
 use rand::random;
 use std::collections::HashMap;
 use time::PreciseTime;
-
-mod test;
-
-#[derive(Copy)]
-struct MoveStats {
-    wins: usize,
-    plays: usize
-}
-
-impl MoveStats {
-    pub fn new() -> MoveStats {
-        MoveStats { wins: 0, plays: 0 }
-    }
-
-    pub fn won(&mut self) {
-        self.wins = self.wins + 1;
-        self.plays = self.plays + 1;
-    }
-
-    pub fn lost(&mut self) {
-        self.plays = self.plays + 1;
-    }
-
-    pub fn all_wins(&self) -> bool {
-        self.wins == self.plays
-    }
-
-    pub fn all_losses(&self) -> bool {
-        self.wins == 0
-    }
-
-    pub fn win_ratio(&self) -> f32 {
-        if self.plays == 0 {
-            0f32
-        } else {
-            (self.wins as f32) / (self.plays as f32)
-        }
-    }
-}
 
 pub struct McEngine;
 

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -43,7 +43,7 @@ impl McEngine {
 
 impl Engine for McEngine {
     fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64) -> Move {
-        let moves = game.legal_moves();
+        let moves = game.legal_moves_without_eyes();
         let start_time = PreciseTime::now();
         let mut stats = HashMap::new();
         for m in moves.iter() {

--- a/src/engine/move_stats/mod.rs
+++ b/src/engine/move_stats/mod.rs
@@ -1,7 +1,7 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014 Thomas Poinsot, Urban Hafner                          *
- * Copyright 2015 Thomas Poinsot                                        *
+ * Copyright 2014 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Thomas Poinsot                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,18 +20,41 @@
  *                                                                      *
  ************************************************************************/
 
-pub use self::mc::McEngine;
-pub use self::move_stats::MoveStats;
-pub use self::random::RandomEngine;
-use board::Color;
-use board::Move;
-use game::Game;
+mod test;
 
-mod mc;
-mod move_stats;
-mod random;
+#[derive(Copy)]
+pub struct MoveStats {
+    wins: usize,
+    plays: usize
+}
 
-pub trait Engine {
-    // args: color of the move to generate, the game on which we play, and the nb of ms we have to generate the move
-    fn gen_move(&self, Color, &Game, i64) -> Move;
+impl MoveStats {
+    pub fn new() -> MoveStats {
+        MoveStats { wins: 0, plays: 0 }
+    }
+
+    pub fn won(&mut self) {
+        self.wins = self.wins + 1;
+        self.plays = self.plays + 1;
+    }
+
+    pub fn lost(&mut self) {
+        self.plays = self.plays + 1;
+    }
+
+    pub fn all_wins(&self) -> bool {
+        self.wins == self.plays
+    }
+
+    pub fn all_losses(&self) -> bool {
+        self.wins == 0
+    }
+
+    pub fn win_ratio(&self) -> f32 {
+        if self.plays == 0 {
+            0f32
+        } else {
+            (self.wins as f32) / (self.plays as f32)
+        }
+    }
 }

--- a/src/engine/move_stats/test.rs
+++ b/src/engine/move_stats/test.rs
@@ -21,11 +21,7 @@
 
 #![cfg(test)]
 
-use board::Black;
-use engine::Engine;
-use game::Game;
-use ruleset::KgsChinese;
-use super::{McEngine, MoveStats};
+use super::MoveStats;
 
 use test::Bencher;
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -160,6 +160,14 @@ impl Game {
             .filter(|&m| self.play(m).is_ok())
             .collect()
     }
+
+    pub fn legal_moves_without_eyes(&self) -> Vec<Move> {
+        self.board
+            .legal_moves_without_eyes()
+            .into_iter()
+            .filter(|&m| self.play(m).is_ok())
+            .collect()
+    }
 }
 
 impl Display for Game {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ mod version;
 fn main() {
     let mut opts = Options::new();
     let args : Vec<String> = args().collect();
-    opts.optopt("e", "engine", "select an engine (defaults to random)", "mc|random");
+    opts.optopt("e", "engine", "select an engine (defaults to mc)", "mc|random");
     opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
     opts.optflag("h", "help", "print this help menu");
     opts.optflag("v", "version", "print the version number");
@@ -86,8 +86,8 @@ fn main() {
     }
     let engine_arg = matches.opt_str("e").map(|s| s.into_ascii_lowercase());
     let engine = match engine_arg {
-        Some(ref s) if s.as_slice() == "mc" => Box::new(McEngine::new()) as Box<Engine>,
-        _                                   => Box::new(RandomEngine::new()) as Box<Engine>
+        Some(ref s) if s.as_slice() == "random" => Box::new(RandomEngine::new()) as Box<Engine>,
+        _                                       => Box::new(McEngine::new()) as Box<Engine>
     };
     let rules_arg = matches.opt_str("r").map(|s| s.into_ascii_lowercase());
     let ruleset = match rules_arg {

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -39,7 +39,7 @@ impl Playout {
         let max_moves = board.size() * board.size() * 3;
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
-            let moves = board.legal_moves_without_superko_check();
+            let moves = board.legal_moves_without_eyes();
             let m = moves[random::<usize>() % moves.len()];
             board.play(m);
             move_count += 1;


### PR DESCRIPTION
Playing in eyes is really stupid and shouldn't be done. This pull request changes both the `McEngine` and the `Playout` to remove those moves from the list of candidate moves. I'm still testing against 0.1.0, but so far the new version hasn't lost a game, yet.