### PR TITLE
Fix division by zero error

### DIFF
--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -44,6 +44,9 @@ impl McEngine {
 impl Engine for McEngine {
     fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64) -> Move {
         let moves = game.legal_moves_without_eyes();
+        if moves.is_empty() {
+            return Pass(color)
+        }
         let start_time = PreciseTime::now();
         let mut stats = HashMap::new();
         for m in moves.iter() {

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -30,7 +30,6 @@ use super::Engine;
 use super::MoveStats;
 
 use rand::random;
-use std::collections::HashMap;
 use time::PreciseTime;
 
 pub struct McEngine;
@@ -48,21 +47,17 @@ impl Engine for McEngine {
             return Pass(color)
         }
         let start_time = PreciseTime::now();
-        let mut stats = HashMap::new();
-        for m in moves.iter() {
-            stats.insert(m, MoveStats::new());
-        }
+        let mut stats = MoveStats::new(&moves, color);
         let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
             let g = game.play(m).unwrap();
             let playout = Playout::new(g.board());
             let winner = playout.run();
-            let mut prev_move_stats = stats.get_mut(&m).unwrap();
             if winner == color {
-                prev_move_stats.won();
+                stats.record_win(&m);
             } else {
-                prev_move_stats.lost();
+                stats.record_loss(&m);
             }
             if counter % 100 == 0 && start_time.to(PreciseTime::now()).num_milliseconds() >= time_to_stop {
                 break;
@@ -70,21 +65,13 @@ impl Engine for McEngine {
             counter += 1;
         }
         // resign if 0% wins
-        if stats.values().all(|stats| stats.all_losses()) {
+        if stats.all_losses() {
             Resign(color)
         // pass if 100% wins
-        } else if stats.values().all(|stats| stats.all_wins()) {
+        } else if stats.all_wins() {
             Pass(color)
         } else {
-            let mut m = Pass(color);
-            let mut move_stats = MoveStats::new();
-            for (m_new, ms) in stats.iter() {
-                if ms.win_ratio() > move_stats.win_ratio() {
-                    m = **m_new;
-                    move_stats = *ms;
-                }
-            }
-            m
+            stats.best()
         }
     }
 }

--- a/src/engine/move_stats/test.rs
+++ b/src/engine/move_stats/test.rs
@@ -21,12 +21,79 @@
 
 #![cfg(test)]
 
-use super::MoveStats;
+pub use super::MoveStat;
+pub use super::MoveStats;
 
-use test::Bencher;
 
-#[test]
-fn newly_produced_move_stats_should_have_0pc_win_ratio() {
-  let ms = MoveStats::new();
-  assert_eq!(ms.win_ratio(), 0f32);
+mod move_stats {
+
+    use board::Black;
+    use board::Pass;
+    use board::Play;
+    use super::MoveStats;
+
+    #[test]
+    fn returns_pass_as_best_move_by_default() {
+        let moves = vec!();
+        let stats = MoveStats::new(&moves, Black);
+        assert_eq!(Pass(Black), stats.best());
+    }
+
+    #[test]
+    fn returns_the_best_move() {
+        let moves = vec![Play(Black, 1, 1), Play(Black, 2, 2)];
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_win(&Play(Black, 1, 1));
+        stats.record_loss(&Play(Black, 1, 1));
+        stats.record_win(&Play(Black, 2, 2));
+        stats.record_win(&Play(Black, 2, 2));
+        assert_eq!(Play(Black, 2, 2), stats.best());
+    }
+
+    #[test]
+    fn all_wins_returns_true_when_no_losses_were_recorded() {
+        let moves = vec![Play(Black, 1, 1), Play(Black, 2, 2)];
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_win(&Play(Black, 1, 1));
+        stats.record_win(&Play(Black, 2, 2));
+        assert!(stats.all_wins());
+    }
+
+    #[test]
+    fn all_wins_returns_false_when_a_loss_was_recorded() {
+        let moves = vec![Play(Black, 1, 1), Play(Black, 2, 2)];
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_loss(&Play(Black, 1, 1));
+        assert!(!stats.all_wins());
+    }
+
+    #[test]
+    fn all_losses_returns_true_when_no_wins_were_recorded() {
+        let moves = vec![Play(Black, 1, 1), Play(Black, 2, 2)];
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_loss(&Play(Black, 1, 1));
+        stats.record_loss(&Play(Black, 2, 2));
+        assert!(stats.all_losses());
+    }
+
+    #[test]
+    fn all_losses_returns_false_when_a_win_was_recorded() {
+        let moves = vec![Play(Black, 1, 1), Play(Black, 2, 2)];
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_win(&Play(Black, 1, 1));
+        assert!(!stats.all_losses());
+    }
+
+}
+
+mod move_stat {
+
+    use super::MoveStat;
+
+    #[test]
+    fn newly_produced_move_stat_should_have_0pc_win_ratio() {
+        let ms = MoveStat::new();
+        assert_eq!(ms.win_ratio(), 0f32);
+    }
+
 }


### PR DESCRIPTION
Now that `Game.legal_moves_without_eyes()` doesn't include a pass anymore, it's possible that the list of moves is empty. Obviously picking a move to simulate from none will fail.

This pull request fixes this bug. It also moves the code to pick the best move out of `McEngine` into `MoveStats`.