### PR TITLE
Don't pass even when win rate in 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * A new engine implementing the AMAF (all moves as first) pattern.
   Almost the same as standard Monte-Carlo, but recording wins and
   losses for all moves of the simulated color.
+* Don't pass even when the win rate calculated through the simulations
+  is 100%. Doing this resulted in losses against a random player.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ as inspiration:
 * [Fuego](http://sourceforge.net/projects/fuego/)
 * [oakfoam](http://oakfoam.com/)
 * [GnuGo](https://www.gnu.org/software/gnugo/)
+* [Brown](http://www.lysator.liu.se/~gunnar/gtp/brown-1.0.tar.gz)
 
 License
 =======

--- a/bin/play-brown
+++ b/bin/play-brown
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DIR=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+cd "$DIR/.."
+
+set -ex
+
+cargo build --release
+
+BROWN="brown"
+IOMRASCALAI="./target/release/iomrascálaí"
+SIZE=9
+TIME="5m"
+
+TWOGTP="gogui-twogtp -black \"$BROWN\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"
+gogui -computer-both -program "$TWOGTP" -size $SIZE

--- a/src/engine/amaf.rs
+++ b/src/engine/amaf.rs
@@ -47,6 +47,7 @@ impl Engine for AmafEngine {
     fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64) -> Move {
         let moves = game.legal_moves_without_eyes();
         if moves.is_empty() {
+            log!("No moves to simulate!");
             return Pass(color)
         }
         let start_time = PreciseTime::now();
@@ -69,14 +70,15 @@ impl Engine for AmafEngine {
             }
             counter += 1;
         }
+        log!("{} simulations", counter);
         // resign if 0% wins
         if stats.all_losses() {
+            log!("All simulations were losses");
             Resign(color)
-        // pass if 100% wins
-        } else if stats.all_wins() {
-            Pass(color)
         } else {
-            stats.best()
+            let (m, s) = stats.best();
+            log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
+            m
         }
 
     }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -44,6 +44,7 @@ impl Engine for McEngine {
     fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64) -> Move {
         let moves = game.legal_moves_without_eyes();
         if moves.is_empty() {
+            log!("No moves to simulate!");
             return Pass(color)
         }
         let start_time = PreciseTime::now();
@@ -64,14 +65,15 @@ impl Engine for McEngine {
             }
             counter += 1;
         }
+        log!("{} simulations", counter);
         // resign if 0% wins
         if stats.all_losses() {
+            log!("All simulations were losses");
             Resign(color)
-        // pass if 100% wins
-        } else if stats.all_wins() {
-            Pass(color)
         } else {
-            stats.best()
+            let (m, s) = stats.best();
+            log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
+            m
         }
     }
 }

--- a/src/engine/move_stats/mod.rs
+++ b/src/engine/move_stats/mod.rs
@@ -68,7 +68,7 @@ impl<'a> MoveStats<'a> {
         self.stats.values().all(|stat| stat.all_wins())
     }
 
-    pub fn best(&self) -> Move {
+    pub fn best(&self) -> (Move, MoveStat) {
         let mut m = Pass(self.color);
         let mut move_stats = MoveStat::new();
         for (m_new, ms) in self.stats.iter() {
@@ -77,7 +77,7 @@ impl<'a> MoveStats<'a> {
                 move_stats = *ms;
             }
         }
-        m
+        (m, move_stats)
     }
 }
 

--- a/src/engine/move_stats/test.rs
+++ b/src/engine/move_stats/test.rs
@@ -36,7 +36,8 @@ mod move_stats {
     fn returns_pass_as_best_move_by_default() {
         let moves = vec!();
         let stats = MoveStats::new(&moves, Black);
-        assert_eq!(Pass(Black), stats.best());
+        let (m, ms) = stats.best();
+        assert_eq!(Pass(Black), m);
     }
 
     #[test]
@@ -47,7 +48,10 @@ mod move_stats {
         stats.record_loss(&Play(Black, 1, 1));
         stats.record_win(&Play(Black, 2, 2));
         stats.record_win(&Play(Black, 2, 2));
-        assert_eq!(Play(Black, 2, 2), stats.best());
+        let (m, ms) = stats.best();
+        assert_eq!(Play(Black, 2, 2), m);
+        assert_eq!(ms.plays, 2);
+        assert_eq!(ms.wins, 2);
     }
 
     #[test]

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -29,8 +29,6 @@ use game::Game;
 use ruleset::Ruleset;
 use timer::Timer;
 
-use std::old_io::stdio::stderr;
-
 pub mod driver;
 mod test;
 
@@ -168,9 +166,8 @@ impl<'a> GTPInterpreter<'a> {
                 let color = Color::from_gtp(command[1]);
                 self.timer.start();
                 let budget = self.timer.budget(&self.game);
-                let mut stream = stderr();
-                stream.write_line(format!("Thinking for {}ms", budget).as_slice());
-                stream.write_line(format!("{}ms time left", self.timer.main_time_left()).as_slice());
+                log!("Thinking for {}ms", budget);
+                log!("{}ms time left", self.timer.main_time_left());
                 let m  = self.engine.gen_move(color, &self.game, budget);
                 match self.game.clone().play(m) {
                     Ok(g) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,15 @@ use getopts::Options;
 use std::ascii::OwnedAsciiExt;
 use std::env::args;
 
+macro_rules! log(
+    ($($arg:tt)*) => (
+        match writeln!(&mut ::std::old_io::stdio::stderr(), $($arg)* ) {
+            Ok(_) => {},
+            Err(x) => panic!("Unable to write to stderr: {}", x),
+        }
+    )
+);
+
 mod board;
 mod engine;
 mod game;


### PR DESCRIPTION
Don't pass even if the bot thinks that it will always win. Doing this resulted in losses against Brown (random player). Now we even play when all possible moves are wins. This of course leads to some kind of random playing (as all moves are rated as 1). This will however be addressed in a separate pull request.