### PR TITLE
Separate time control from engines

### DIFF
--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DIR=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+cd "$DIR/.."
+
+set -ex
+
+cargo clean
+cargo build --release
+
+GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
+IOMRASCALAI="./target/release/iomrascálaí"
+SIZE=9
+TIME="5m"
+
+TWOGTP="gogui-twogtp -black \"$GNUGO\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"
+gogui -computer-both -program "$TWOGTP" -size $SIZE

--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -5,7 +5,6 @@ cd "$DIR/.."
 
 set -ex
 
-cargo clean
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -35,7 +35,7 @@ use self::point::Point;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::vec::Vec;
 
 mod test;
@@ -99,8 +99,8 @@ pub struct Board {
     friend_stones_removed: Vec<Coord>,
     ko:                    Option<Coord>,
     komi:                  f32,
-    neighbours:            Rc<Vec<Vec<Coord>>>,
-    orthogonals:           Rc<Vec<Vec<Coord>>>,
+    neighbours:            Arc<Vec<Vec<Coord>>>,
+    orthogonals:           Arc<Vec<Vec<Coord>>>,
     previous_player:       Color,
     resigned_by:           Color,
     ruleset:               Ruleset,
@@ -149,20 +149,20 @@ impl Board {
         }
     }
 
-    fn setup_neighbours(size: u8) -> Rc<Vec<Vec<Coord>>> {
+    fn setup_neighbours(size: u8) -> Arc<Vec<Vec<Coord>>> {
         let mut neighbours = Vec::new();
         for coord in Coord::for_board_size(size).iter() {
             neighbours.push(coord.neighbours(size));
         }
-        Rc::new(neighbours)
+        Arc::new(neighbours)
     }
 
-    fn setup_orthogonals(size: u8) -> Rc<Vec<Vec<Coord>>> {
+    fn setup_orthogonals(size: u8) -> Arc<Vec<Vec<Coord>>> {
         let mut orthogonals = Vec::new();
         for coord in Coord::for_board_size(size).iter() {
             orthogonals.push(coord.orthogonals(size));
         }
-        Rc::new(orthogonals)
+        Arc::new(orthogonals)
     }
 
     pub fn neighbours(&self, c: Coord) -> &Vec<Coord> {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -518,8 +518,8 @@ impl Board {
     }
 
     fn create_new_chain(&mut self, m: &Move) -> usize {
-        let new_chain_id    = self.chains.len();
-        let mut new_chain   = Chain::new(
+        let new_chain_id = self.chains.len();
+        let new_chain    = Chain::new(
             new_chain_id, *m.color(), m.coord(), self.liberties(&m.coord()));
         self.chains.push(new_chain);
         self.board[m.coord().to_index(self.size)].chain_id = new_chain_id;

--- a/src/engine/amaf.rs
+++ b/src/engine/amaf.rs
@@ -53,6 +53,7 @@ impl Engine for AmafEngine {
             return;
         }
         let mut stats = MoveStats::new(&moves, color);
+        let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
             let g = game.play(m).unwrap();
@@ -65,6 +66,7 @@ impl Engine for AmafEngine {
                     stats.record_loss(&m2);
                 }
             }
+            counter += 1;
             if receiver.try_recv().is_ok() {
                 break;
             }

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -27,6 +27,7 @@ use timer::Timer;
 
 use std::old_io::stdio::stderr;
 use std::sync::mpsc::channel;
+use std::thread;
 
 pub struct EngineController<'a> {
     engine: Box<Engine + 'a>,
@@ -43,7 +44,9 @@ impl<'a> EngineController<'a> {
     pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &mut Timer) -> Move {
         let budget = self.budget(timer, game);
         let (send_to_controller, receive_from_engine) = channel::<Move>();
-        self.engine.gen_move(color, game, budget, send_to_controller);
+        thread::scoped(|| {
+            self.engine.gen_move(color, game, budget, send_to_controller);
+        });
         receive_from_engine.recv().unwrap()
     }
 

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -31,6 +31,8 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::time::duration::Duration;
 
+mod test;
+
 pub struct EngineController<'a> {
     engine: Box<Engine + 'a>,
 }

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -1,7 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014 Thomas Poinsot, Urban Hafner                          *
- * Copyright 2015 Thomas Poinsot                                        *
+ * Copyright 2015 Urban Hafner                                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,22 +19,32 @@
  *                                                                      *
  ************************************************************************/
 
-pub use self::amaf::AmafEngine;
-pub use self::controller::EngineController;
-pub use self::mc::McEngine;
-pub use self::move_stats::MoveStats;
-pub use self::random::RandomEngine;
 use board::Color;
 use board::Move;
+use engine::Engine;
 use game::Game;
+use timer::Timer;
 
-mod amaf;
-mod controller;
-mod mc;
-mod move_stats;
-mod random;
+use std::old_io::stdio::stderr;
 
-pub trait Engine {
-    // args: color of the move to generate, the game on which we play, and the nb of ms we have to generate the move
-    fn gen_move(&self, Color, &Game, i64) -> Move;
+pub struct EngineController<'a> {
+    engine: Box<Engine + 'a>,
+}
+
+impl<'a> EngineController<'a> {
+
+    pub fn new<'b>(engine: Box<Engine + 'b>) -> EngineController<'b> {
+        EngineController {
+            engine: engine,
+        }
+    }
+
+    pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &mut Timer) -> Move {
+        timer.start();
+        let budget = timer.budget(game);
+        let mut stream = stderr();
+        stream.write_line(format!("Thinking for {}ms", budget).as_slice());
+        stream.write_line(format!("{}ms time left", timer.main_time_left()).as_slice());
+        self.engine.gen_move(color, game, budget)
+    }
 }

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -1,0 +1,27 @@
+/************************************************************************
+ *                                                                      *
+ * Copyright 2015 Urban Hafner                                          *
+ *                                                                      *
+ * This file is part of Iomrascálaí.                                    *
+ *                                                                      *
+ * Iomrascálaí is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by *
+ * the Free Software Foundation, either version 3 of the License, or    *
+ * (at your option) any later version.                                  *
+ *                                                                      *
+ * Iomrascálaí is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ * GNU General Public License for more details.                         *
+ *                                                                      *
+ * You should have received a copy of the GNU General Public License    *
+ * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
+ *                                                                      *
+ ************************************************************************/
+
+#![cfg(test)]
+
+#[test]
+fn test_the_engine_controller() {
+    assert!(false);
+}

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -30,6 +30,7 @@ use super::Engine;
 use super::MoveStats;
 
 use rand::random;
+use std::sync::mpsc::Sender;
 use time::PreciseTime;
 
 pub struct McEngine;
@@ -41,11 +42,12 @@ impl McEngine {
 }
 
 impl Engine for McEngine {
-    fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64) -> Move {
+    fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64, sender: Sender<Move>) {
         let moves = game.legal_moves_without_eyes();
         if moves.is_empty() {
             log!("No moves to simulate!");
-            return Pass(color)
+            sender.send(Pass(color));
+            return;
         }
         let start_time = PreciseTime::now();
         let mut stats = MoveStats::new(&moves, color);
@@ -69,11 +71,11 @@ impl Engine for McEngine {
         // resign if 0% wins
         if stats.all_losses() {
             log!("All simulations were losses");
-            Resign(color)
+            sender.send(Resign(color));
         } else {
             let (m, s) = stats.best();
             log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
-            m
+            sender.send(m);
         }
     }
 }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -30,8 +30,8 @@ use super::Engine;
 use super::MoveStats;
 
 use rand::random;
+use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
-use time::PreciseTime;
 
 pub struct McEngine;
 
@@ -42,16 +42,14 @@ impl McEngine {
 }
 
 impl Engine for McEngine {
-    fn gen_move(&self, color: Color, game: &Game, time_to_stop: i64, sender: Sender<Move>) {
+    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
         let moves = game.legal_moves_without_eyes();
         if moves.is_empty() {
             log!("No moves to simulate!");
             sender.send(Pass(color));
             return;
         }
-        let start_time = PreciseTime::now();
         let mut stats = MoveStats::new(&moves, color);
-        let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
             let g = game.play(m).unwrap();
@@ -62,10 +60,9 @@ impl Engine for McEngine {
             } else {
                 stats.record_loss(&m);
             }
-            if counter % 100 == 0 && start_time.to(PreciseTime::now()).num_milliseconds() >= time_to_stop {
+            if receiver.try_recv().is_ok() {
                 break;
             }
-            counter += 1;
         }
         log!("{} simulations", counter);
         // resign if 0% wins

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -50,6 +50,7 @@ impl Engine for McEngine {
             return;
         }
         let mut stats = MoveStats::new(&moves, color);
+        let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
             let g = game.play(m).unwrap();
@@ -60,6 +61,7 @@ impl Engine for McEngine {
             } else {
                 stats.record_loss(&m);
             }
+            counter += 1;
             if receiver.try_recv().is_ok() {
                 break;
             }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -29,6 +29,7 @@ use board::Color;
 use board::Move;
 use game::Game;
 
+use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 mod amaf;
@@ -39,5 +40,5 @@ mod random;
 
 pub trait Engine: Sync {
     // args: color of the move to generate, the game on which we play, and the nb of ms we have to generate the move
-    fn gen_move(&self, Color, &Game, i64, sender: Sender<Move>);
+    fn gen_move(&self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -37,7 +37,7 @@ mod mc;
 mod move_stats;
 mod random;
 
-pub trait Engine {
+pub trait Engine: Sync {
     // args: color of the move to generate, the game on which we play, and the nb of ms we have to generate the move
     fn gen_move(&self, Color, &Game, i64, sender: Sender<Move>);
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -29,6 +29,8 @@ use board::Color;
 use board::Move;
 use game::Game;
 
+use std::sync::mpsc::Sender;
+
 mod amaf;
 mod controller;
 mod mc;
@@ -37,5 +39,5 @@ mod random;
 
 pub trait Engine {
     // args: color of the move to generate, the game on which we play, and the nb of ms we have to generate the move
-    fn gen_move(&self, Color, &Game, i64) -> Move;
+    fn gen_move(&self, Color, &Game, i64, sender: Sender<Move>);
 }

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -27,6 +27,7 @@ use engine::Engine;
 use game::Game;
 
 use rand::random;
+use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct RandomEngine;
@@ -38,7 +39,7 @@ impl RandomEngine {
 }
 
 impl Engine for RandomEngine {
-    fn gen_move(&self, color: Color, game: &Game, _: i64, sender: Sender<Move>) {
+    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, _: Receiver<()>) {
         let mut moves = game.legal_moves();
         moves.push(Pass(color));
         let m = moves[random::<usize>() % moves.len()];

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -27,6 +27,7 @@ use engine::Engine;
 use game::Game;
 
 use rand::random;
+use std::sync::mpsc::Sender;
 
 pub struct RandomEngine;
 
@@ -37,9 +38,10 @@ impl RandomEngine {
 }
 
 impl Engine for RandomEngine {
-    fn gen_move(&self, color: Color, game: &Game, _: i64) -> Move {
+    fn gen_move(&self, color: Color, game: &Game, _: i64, sender: Sender<Move>) {
         let mut moves = game.legal_moves();
         moves.push(Pass(color));
-        moves[random::<usize>() % moves.len()]
+        let m = moves[random::<usize>() % moves.len()];
+        sender.send(m);
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -32,7 +32,7 @@ use self::hash::ZobristHashTable;
 
 use std::fmt;
 use core::fmt::Display;
-use std::rc::Rc;
+use std::sync::Arc;
 
 mod hash;
 mod test;
@@ -49,12 +49,12 @@ pub struct Game {
     board: Board,
     move_number: u16,
     previous_boards_hashes: Vec<u64>,
-    zobrist_base_table: Rc<ZobristHashTable>
+    zobrist_base_table: Arc<ZobristHashTable>,
 }
 
 impl Game {
     pub fn new(size: u8, komi: f32, ruleset: Ruleset) -> Game {
-        let zobrist_base_table = Rc::new(ZobristHashTable::new(size));
+        let zobrist_base_table = Arc::new(ZobristHashTable::new(size));
         let new_board = Board::new(size, komi, ruleset);
 
         Game {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,13 +20,11 @@
  ************************************************************************/
 #![feature(collections)]
 #![feature(core)]
-#![feature(env)]
-#![feature(hash)]
-#![feature(io)]
-#![feature(path)]
+#![feature(old_io)]
+#![feature(old_path)]
 #![feature(plugin)]
-#![feature(test)]
 #![feature(std_misc)]
+#![feature(test)]
 #![feature(unicode)]
 #![plugin(regex_macros)]
 extern crate core;

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -19,6 +19,8 @@
  *                                                                      *
  ************************************************************************/
 
+#![cfg(test)]
+
 use playout::Playout;
 use game::Game;
 use ruleset::KgsChinese;


### PR DESCRIPTION
This moves the timing code out of the `McEngine` and `AmafEngine` structs into a separate `EngineController` struct. There's still a lot of copied code between the two, but it's already as start.