### PR TITLE
DRY up McEngine and AmafEngine & make AmafEngine default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.1.4 [☰](https://github.com/ujh/iomrascalai/compare/0.1.3...master)
 
+* Make AMAF the default engine. This was supposed to be the default
+  for 0.1.3, but didn't happen so the win rates recorded for 0.1.3 are
+  useless!
+* Refactored the engine code, to but the shared code of the MC and the
+  AMAF into a trait.
+
 ## 0.1.3 [☰](https://github.com/ujh/iomrascalai/compare/0.1.2...0.1.3)
 
 ### Changes

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -11,8 +11,8 @@ rm -f gnugo-benchmark*
 rm -f previous-version-benchmark*
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-IOMRASCALAI="./target/release/iomrascalai -e mc"
-PREVIOUS="iomrascalai-$1 -e mc"
+IOMRASCALAI="./target/release/iomrascalai"
+PREVIOUS="iomrascalai-$1"
 REFEREE="$GNUGO"
 SIZE=9
 GAMES=100

--- a/bin/play-amigogtp
+++ b/bin/play-amigogtp
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DIR=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+cd "$DIR/.."
+
+set -ex
+
+cargo build --release
+
+AMIGO="amigogtp"
+IOMRASCALAI="./target/release/iomrascalai"
+SIZE=9
+TIME="5m"
+
+TWOGTP="gogui-twogtp -black \"$AMIGOGTP\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"
+gogui -computer-both -program "$TWOGTP" -size $SIZE

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -1,7 +1,7 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014 Thomas Poinsot, Urban Hafner                          *
- * Copyright 2015 Thomas Poinsot                                        *
+ * Copyright 2014 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Thomas Poinsot                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,25 +20,44 @@
  *                                                                      *
  ************************************************************************/
 
-pub use self::controller::EngineController;
-pub use self::mc::AmafMcEngine;
-pub use self::mc::SimpleMcEngine;
-pub use self::move_stats::MoveStats;
-pub use self::random::RandomEngine;
 use board::Color;
 use board::Move;
 use game::Game;
+use playout::Playout;
+use super::Engine;
+use super::McEngine;
+use super::MoveStats;
 
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
-mod controller;
-mod mc;
-mod move_stats;
-mod random;
+pub struct AmafMcEngine;
 
-pub trait Engine: Sync {
+impl AmafMcEngine {
 
-    fn gen_move(&self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
+    pub fn new() -> AmafMcEngine {
+        AmafMcEngine
+    }
 
+}
+
+impl Engine for AmafMcEngine {
+
+    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+        self.mc_gen_move(color, game, sender, receiver);
+    }
+
+}
+
+impl McEngine for AmafMcEngine {
+
+    fn record_playout(&self, stats: &mut MoveStats, _: &Move, playout: &Playout, won: bool) {
+        for m2 in playout.moves().iter() {
+            if won {
+                stats.record_win(&m2);
+            } else {
+                stats.record_loss(&m2);
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,9 +37,9 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate test;
 extern crate time;
 
-use engine::AmafEngine;
+use engine::AmafMcEngine;
 use engine::Engine;
-use engine::McEngine;
+use engine::SimpleMcEngine;
 use engine::RandomEngine;
 use gtp::driver::Driver;
 use ruleset::KgsChinese;
@@ -97,11 +97,11 @@ fn main() {
         Some(s) => {
             match s.as_slice() {
                 "random" => Box::new(RandomEngine::new()),
-                "mc"     => Box::new(McEngine::new()),
-                _        => Box::new(AmafEngine::new()),
+                "mc"     => Box::new(SimpleMcEngine::new()),
+                _        => Box::new(AmafMcEngine::new()),
             }
         },
-        None => Box::new(McEngine::new())
+        None => Box::new(AmafMcEngine::new())
     };
     let rules_arg = matches.opt_str("r").map(|s| s.into_ascii_lowercase());
     let ruleset = match rules_arg {


### PR DESCRIPTION
I was going to start parallelizing the engines but I wanted to DRY up the code in `McEngine` and `AmafEngine` first. So that's what I did here. I'm not totally happy how the `Engine` and `McEngine` traits are separate, but I'm not even sure if trait inheritance is possible.

Also, this changes the default engine to AMAF. This is bigger than you might think, as this means that the win rates I recorded in CHANGELOG.md for 0.1.3 are useless as I used the default engine which was `McEngine` and not `AmafEngine` as I previously though. This should also explain why 0.1.3 wasn't stronger than 0.1.2. :flushed: 