### PR TITLE
Fix bug in resign logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "regex 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.19 (git+https://github.com/rust-lang/time)",
+ "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "time"
 version = "0.1.19"
-source = "git+https://github.com/rust-lang/time#cb2f392ac5eea66de3c79a747c0dc455bf32f1f3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "regex 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.19 (git+https://github.com/rust-lang/time)",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "time"
 version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/rust-lang/time#cb2f392ac5eea66de3c79a747c0dc455bf32f1f3"
 dependencies = [
  "gcc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,4 @@ rand            = "*"
 regex           = "*"
 regex_macros    = "*"
 rustc-serialize = "*"
-#time            = "*"
-
-[dependencies.time]
-
-git = "https://github.com/rust-lang/time"
+time            = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,9 @@ rand            = "*"
 regex           = "*"
 regex_macros    = "*"
 rustc-serialize = "*"
-time            = "*"
+# Temporarily use the github time crate, due to a Windowns bug in the released version
+# time            = "*"
+
+[dependencies.time]
+
+git = "https://github.com/rust-lang/time"

--- a/bin/play-amigogtp
+++ b/bin/play-amigogtp
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 AMIGO="amigogtp"
-IOMRASCALAI="./target/release/iomrascalai"
+IOMRASCALAI="./target/release/iomrascalai -e $1"
 SIZE=9
 TIME="5m"
 

--- a/bin/play-brown
+++ b/bin/play-brown
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 BROWN="brown"
-IOMRASCALAI="./target/release/iomrascalai"
+IOMRASCALAI="./target/release/iomrascalai -e $1"
 SIZE=9
 TIME="5m"
 

--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-IOMRASCALAI="./target/release/iomrascalai"
+IOMRASCALAI="./target/release/iomrascalai -e $1"
 SIZE=9
 TIME="5m"
 

--- a/src/board/movement/test.rs
+++ b/src/board/movement/test.rs
@@ -58,7 +58,7 @@ fn extract_color_from_resign() {
 }
 
 #[test]
-#[should_fail]
+#[should_panic]
 fn fail_when_trying_to_get_coord_of_resign() {
     let m = Resign(White);
     m.coord(); // This should blow up

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -50,7 +50,7 @@ fn getting_a_valid_coord_returns_a_color() {
 }
 
 #[test]
-#[should_fail]
+#[should_panic]
 fn getting_invalid_coordinates_fails() {
     let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 
@@ -66,7 +66,7 @@ fn _19_19_is_a_valid_coordinate(){
 }
 
 #[test]
-#[should_fail]
+#[should_panic]
 fn _0_0_is_not_a_valid_coordinate(){
     let b = Board::new(19, 6.5, AnySizeTrompTaylor);
 

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -71,9 +71,7 @@ impl<'a> EngineController<'a> {
     fn budget(&self, timer: &mut Timer, game: &Game) -> i64 {
         timer.start();
         let budget = timer.budget(game);
-        let mut stream = stderr();
-        stream.write_line(format!("Thinking for {}ms", budget).as_slice());
-        stream.write_line(format!("{}ms time left", timer.main_time_left()).as_slice());
+        log!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left());
         budget
     }
 

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -51,12 +51,12 @@ impl Engine for AmafMcEngine {
 
 impl McEngine for AmafMcEngine {
 
-    fn record_playout(&self, stats: &mut MoveStats, _: &Move, playout: &Playout, won: bool) {
-        for m2 in playout.moves().iter() {
+    fn record_playout(&self, stats: &mut MoveStats, playout: &Playout, won: bool) {
+        for m in playout.moves().iter() {
             if won {
-                stats.record_win(&m2);
+                stats.record_win(&m);
             } else {
-                stats.record_loss(&m2);
+                stats.record_loss(&m);
             }
         }
     }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -51,7 +51,7 @@ pub trait McEngine {
         let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
-            let playout = Playout::new(&game.board(), &m);
+            let playout = Playout::run(&game.board(), &m);
             let winner = playout.winner();
             self.record_playout(&mut stats, &playout, winner == color);
             counter += 1;

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -63,8 +63,13 @@ pub trait McEngine {
         log!("{} simulations", counter);
         // resign if 0% wins
         if stats.all_losses() {
+            if game.winner() == color {
+            log!("All simulations were losses, however passing leads to a win");
+                sender.send(Pass(color));
+            } else {
             log!("All simulations were losses");
-            sender.send(Resign(color));
+                sender.send(Resign(color));
+            }
         } else {
             let (m, s) = stats.best();
             log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -51,10 +51,9 @@ pub trait McEngine {
         let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
-            let g = game.play(m).unwrap();
-            let mut playout = Playout::new(g.board());
-            let winner = playout.run();
-            self.record_playout(&mut stats, &m, &playout, winner == color);
+            let mut playout = Playout::new(game.board());
+            let winner = playout.run(&m);
+            self.record_playout(&mut stats, &playout, winner == color);
             counter += 1;
             if receiver.try_recv().is_ok() {
                 break;
@@ -72,6 +71,6 @@ pub trait McEngine {
         }
     }
 
-    fn record_playout(&self, &mut MoveStats, &Move, &Playout, bool);
+    fn record_playout(&self, &mut MoveStats, &Playout, bool);
 
 }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -51,8 +51,8 @@ pub trait McEngine {
         let mut counter = 0;
         loop {
             let m = moves[random::<usize>() % moves.len()];
-            let mut playout = Playout::new(game.board());
-            let winner = playout.run(&m);
+            let playout = Playout::new(&game.board(), &m);
+            let winner = playout.winner();
             self.record_playout(&mut stats, &playout, winner == color);
             counter += 1;
             if receiver.try_recv().is_ok() {

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -63,13 +63,8 @@ pub trait McEngine {
         log!("{} simulations", counter);
         // resign if 0% wins
         if stats.all_losses() {
-            if game.winner() == color {
-            log!("All simulations were losses, however passing leads to a win");
-                sender.send(Pass(color));
-            } else {
             log!("All simulations were losses");
-                sender.send(Resign(color));
-            }
+            sender.send(Resign(color));
         } else {
             let (m, s) = stats.best();
             log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -47,7 +47,8 @@ impl Engine for SimpleMcEngine {
 
 impl McEngine for SimpleMcEngine {
 
-    fn record_playout(&self, stats: &mut MoveStats, m: &Move, _: &Playout, won: bool) {
+    fn record_playout(&self, stats: &mut MoveStats, playout: &Playout, won: bool) {
+        let m = playout.moves()[0];
         if won {
             stats.record_win(&m);
         } else {

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -34,7 +34,7 @@ pub struct Playout {
 }
 
 impl Playout {
-    pub fn new(b: &Board, initial_move: &Move) -> Playout {
+    pub fn run(b: &Board, initial_move: &Move) -> Playout {
         let mut board = b.clone();
         let mut played_moves = Vec::new();
         board.play(*initial_move);

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -41,8 +41,10 @@ impl Playout {
         }
     }
 
-    pub fn run(&mut self) -> Color {
+    pub fn run(&mut self, initial_move: &Move) -> Color {
         let mut board = self.board.clone();
+        board.play(*initial_move);
+        self.moves.push(*initial_move);
         let max_moves = board.size() * board.size() * 3;
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -29,22 +29,16 @@ use rand::random;
 mod test;
 
 pub struct Playout {
-    board: Board,
     moves: Vec<Move>,
+    winner: Color,
 }
 
 impl Playout {
-    pub fn new(b: Board) -> Playout {
-        Playout {
-            board: b,
-            moves: Vec::new(),
-        }
-    }
-
-    pub fn run(&mut self, initial_move: &Move) -> Color {
-        let mut board = self.board.clone();
+    pub fn new(b: &Board, initial_move: &Move) -> Playout {
+        let mut board = b.clone();
+        let mut played_moves = Vec::new();
         board.play(*initial_move);
-        self.moves.push(*initial_move);
+        played_moves.push(*initial_move);
         let max_moves = board.size() * board.size() * 3;
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
@@ -56,14 +50,20 @@ impl Playout {
                 moves[random::<usize>() % moves.len()]
             };
             board.play(m);
-            self.moves.push(m);
+            played_moves.push(m);
             move_count += 1;
         }
-        board.winner()
+        Playout {
+            moves: played_moves,
+            winner: board.winner(),
+        }
     }
 
     pub fn moves(&self) -> &Vec<Move> {
         &self.moves
     }
 
+    pub fn winner(&self) -> Color {
+        self.winner
+    }
 }

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -21,9 +21,12 @@
 
 #![cfg(test)]
 
-use playout::Playout;
+use board::Black;
+use board::Play;
 use game::Game;
+use playout::Playout;
 use ruleset::KgsChinese;
+
 use test::Bencher;
 
 #[bench]
@@ -32,7 +35,7 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
     let board = game.board();
     let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run()})
+    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
 }
 
 #[bench]
@@ -41,7 +44,7 @@ fn bench_13x13_playout_speed(b: &mut Bencher) {
     let board = game.board();
     let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run()})
+    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
 }
 
 #[bench]
@@ -50,5 +53,5 @@ fn bench_19x19_playout_speed(b: &mut Bencher) {
     let board = game.board();
     let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run()})
+    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
 }

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -33,7 +33,7 @@ use test::Bencher;
 fn should_add_the_passed_moves_as_the_first_move() {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
-    let playout = Playout::new(&board, &Play(Black, 1, 1));
+    let playout = Playout::run(&board, &Play(Black, 1, 1));
     assert_eq!(Play(Black, 1, 1), playout.moves()[0]);
 }
 
@@ -43,7 +43,7 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
 
-    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
+    b.iter(|| Playout::run(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
@@ -51,7 +51,7 @@ fn bench_13x13_playout_speed(b: &mut Bencher) {
     let game = Game::new(13, 6.5, KgsChinese);
     let board = game.board();
 
-    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
+    b.iter(|| Playout::run(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
@@ -59,5 +59,5 @@ fn bench_19x19_playout_speed(b: &mut Bencher) {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
 
-    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
+    b.iter(|| Playout::run(&board, &Play(Black, 1, 1)))
 }

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -29,29 +29,35 @@ use ruleset::KgsChinese;
 
 use test::Bencher;
 
+#[test]
+fn should_add_the_passed_moves_as_the_first_move() {
+    let game = Game::new(9, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = Playout::new(&board, &Play(Black, 1, 1));
+    assert_eq!(Play(Black, 1, 1), playout.moves()[0]);
+}
+
+
 #[bench]
 fn bench_9x9_playout_speed(b: &mut Bencher) {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
-    let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
+    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
 fn bench_13x13_playout_speed(b: &mut Bencher) {
     let game = Game::new(13, 6.5, KgsChinese);
     let board = game.board();
-    let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
+    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
 fn bench_19x19_playout_speed(b: &mut Bencher) {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
-    let mut playout_engine = Playout::new(board);
 
-    b.iter(|| {playout_engine.run(&Play(Black, 1, 1))})
+    b.iter(|| Playout::new(&board, &Play(Black, 1, 1)))
 }

--- a/src/ruleset/test/from_string.rs
+++ b/src/ruleset/test/from_string.rs
@@ -48,7 +48,7 @@ fn parses_minimal() {
 }
 
 #[test]
-#[should_fail]
+#[should_panic]
 fn fails_with_unknown() {
     Ruleset::from_string(String::from_str("unknown"));
 }


### PR DESCRIPTION
The bot lost against Brown (random player) as it resigned when all
simulated moves lead to a loss. At the end of the game this can however
happen when the only possible moves are plays in the opponents eyes.

So now we only resign if both all simulations lead to a loss and playing
a pass move would lead to a loss.