### PR TITLE
Parallel engines (work in progress)

### DIFF
--- a/bin/play-amigogtp
+++ b/bin/play-amigogtp
@@ -7,7 +7,7 @@ set -ex
 
 cargo build --release
 
-AMIGO="amigogtp"
+AMIGOGTP="amigogtp"
 IOMRASCALAI="./target/release/iomrascalai -e $1"
 SIZE=9
 TIME="5m"

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -44,14 +44,14 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        self.mc_gen_move(color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(color, game, sender, receiver);
     }
 
 }
 
 impl McEngine for AmafMcEngine {
 
-    fn record_playout(&self, stats: &mut MoveStats, playout: &Playout, won: bool) {
+    fn record_playout(stats: &mut MoveStats, playout: &Playout, won: bool) {
         for m in playout.moves().iter() {
             if won {
                 stats.record_win(&m);
@@ -60,4 +60,5 @@ impl McEngine for AmafMcEngine {
             }
         }
     }
+
 }

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -31,12 +31,14 @@ use super::MoveStats;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
-pub struct AmafMcEngine;
+pub struct AmafMcEngine {
+    threads: usize
+}
 
 impl AmafMcEngine {
 
-    pub fn new() -> AmafMcEngine {
-        AmafMcEngine
+    pub fn new(threads: usize) -> AmafMcEngine {
+        AmafMcEngine { threads: threads }
     }
 
 }
@@ -44,7 +46,7 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<AmafMcEngine>(color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(self.threads, color, game, sender, receiver);
     }
 
 }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -63,7 +63,7 @@ pub trait McEngine {
             let (send_halt, receive_halt) = channel::<()>();
             halt_senders.push(send_halt);
             let send_result = send_result.clone();
-            let guard = self.spin_up(receive_halt, moves, game.board(), send_result);
+            let guard = spin_up(receive_halt, moves, game.board(), send_result);
             guards.push(guard);
         }
         loop {
@@ -76,42 +76,42 @@ pub trait McEngine {
                 },
                 _ = receiver.recv() => {
                     log!("{} simulations", counter);
-                    self.finish(color, stats, sender, halt_senders);
+                    finish(color, stats, sender, halt_senders);
                     break;
                 }
                 )
         }
     }
 
-    fn spin_up(&self, recv_halt: Receiver<()>, moves: Arc<Vec<Move>>, board: Board, send_result: Sender<Playout>) -> thread::JoinGuard<()> {
-        thread::scoped(move || {
-            loop {
-                if recv_halt.try_recv().is_ok() {
-                    break;
-                } else {
-                    let m = moves[random::<usize>() % moves.len()];
-                    let playout = Playout::run(&board, &m);
-                    send_result.send(playout);
-                }
-            }
-        })
-    }
-
-    fn finish(&self, color: Color, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) {
-        // resign if 0% wins
-        if stats.all_losses() {
-            log!("All simulations were losses");
-            sender.send(Resign(color));
-        } else {
-            let (m, s) = stats.best();
-            log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
-            sender.send(m);
-        }
-        for halt_sender in halt_senders.iter() {
-            halt_sender.send(());
-        }
-    }
-
     fn record_playout(&self, &mut MoveStats, &Playout, bool);
 
+}
+
+fn finish(color: Color, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) {
+    // resign if 0% wins
+    if stats.all_losses() {
+        log!("All simulations were losses");
+        sender.send(Resign(color));
+    } else {
+        let (m, s) = stats.best();
+        log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
+        sender.send(m);
+    }
+    for halt_sender in halt_senders.iter() {
+        halt_sender.send(());
+    }
+}
+
+fn spin_up<'a>(recv_halt: Receiver<()>, moves: Arc<Vec<Move>>, board: Board, send_result: Sender<Playout>) -> thread::JoinGuard<'a, ()> {
+    thread::scoped(move || {
+        loop {
+            if recv_halt.try_recv().is_ok() {
+                break;
+            } else {
+                let m = moves[random::<usize>() % moves.len()];
+                let playout = Playout::run(&board, &m);
+                send_result.send(playout);
+            }
+        }
+    })
 }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -34,7 +34,6 @@ use playout::Playout;
 
 use rand::random;
 use std::marker::MarkerTrait;
-use std::os::num_cpus;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
@@ -50,9 +49,8 @@ pub trait McEngine: MarkerTrait {
 
 }
 
-fn gen_move<T: McEngine>(color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+fn gen_move<T: McEngine>(threads: usize, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
     let moves = game.legal_moves_without_eyes();
-    let threads = num_cpus();
     if moves.is_empty() {
         log!("No moves to simulate!");
         sender.send(Pass(color));

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -72,17 +72,21 @@ fn gen_move<T: McEngine>(color: Color, game: &Game, sender: Sender<Move>, receiv
             },
             _ = receiver.recv() => {
                 log!("{} simulations", counter);
-                finish(color, stats, sender, halt_senders);
+                finish(color, game, stats, sender, halt_senders);
                 break;
             }
             )
     }
 }
 
-fn finish(color: Color, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) {
+fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) {
     if stats.all_losses() {
         log!("All simulations were losses");
-        sender.send(Resign(color));
+        if game.winner() == color {
+            sender.send(Pass(color));
+        } else {
+            sender.send(Resign(color));
+        }
     } else {
         let (m, s) = stats.best();
         log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -34,7 +34,6 @@ use playout::Playout;
 
 use rand::random;
 use std::marker::MarkerTrait;
-use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
@@ -97,7 +96,7 @@ fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, hal
 fn spin_up<'a, T: McEngine>(color: Color, threads: usize, moves: &'a Vec<Move>, game: &Game, send_result: Sender<(MoveStats<'a>, usize)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {
     let mut guards = Vec::new();
     let mut halt_senders = Vec::new();
-    for i in range(0, threads) {
+    for _ in range(0, threads) {
         let (send_halt, receive_halt) = channel::<()>();
         halt_senders.push(send_halt);
         let send_result = send_result.clone();

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -31,18 +31,20 @@ use super::MoveStats;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
-pub struct SimpleMcEngine;
+pub struct SimpleMcEngine {
+    threads: usize
+}
 
 impl SimpleMcEngine {
-    pub fn new() -> SimpleMcEngine {
-        SimpleMcEngine
+    pub fn new(threads: usize) -> SimpleMcEngine {
+        SimpleMcEngine { threads: threads }
     }
 
 }
 
 impl Engine for SimpleMcEngine {
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(color, game, sender, receiver);
+        super::gen_move::<SimpleMcEngine>(self.threads, color, game, sender, receiver);
     }
 }
 

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -37,17 +37,18 @@ impl SimpleMcEngine {
     pub fn new() -> SimpleMcEngine {
         SimpleMcEngine
     }
+
 }
 
 impl Engine for SimpleMcEngine {
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        self.mc_gen_move(color, game, sender, receiver);
+        super::gen_move::<SimpleMcEngine>(color, game, sender, receiver);
     }
 }
 
 impl McEngine for SimpleMcEngine {
 
-    fn record_playout(&self, stats: &mut MoveStats, playout: &Playout, won: bool) {
+    fn record_playout(stats: &mut MoveStats, playout: &Playout, won: bool) {
         let m = playout.moves()[0];
         if won {
             stats.record_win(&m);

--- a/src/engine/move_stats/mod.rs
+++ b/src/engine/move_stats/mod.rs
@@ -79,6 +79,16 @@ impl<'a> MoveStats<'a> {
         }
         (m, move_stats)
     }
+
+    pub fn merge(&mut self, ms: &MoveStats) {
+        for (m, ms) in ms.stats.iter() {
+            match self.stats.get_mut(m) {
+                Some(s) => { s.merge(ms); },
+                None    => {}
+            }
+        }
+    }
+
 }
 
 
@@ -116,5 +126,10 @@ impl MoveStat {
         } else {
             (self.wins as f32) / (self.plays as f32)
         }
+    }
+
+    pub fn merge(&mut self, ms: &MoveStat) {
+        self.wins += ms.wins;
+        self.plays += ms.plays;
     }
 }

--- a/src/engine/move_stats/test.rs
+++ b/src/engine/move_stats/test.rs
@@ -103,6 +103,32 @@ mod move_stats {
         stats.record_loss(&Play(Black, 1, 1));
     }
 
+    #[test]
+    fn merge_merges_stats_existing_in_both() {
+        let m = Play(Black, 1, 1);
+        let moves = vec!(m);
+        let mut stats = MoveStats::new(&moves, Black);
+        stats.record_win(&m);
+        let mut other = MoveStats::new(&moves, Black);
+        other.record_loss(&m);
+        stats.merge(&other);
+        let ms = stats.stats.get(&m).unwrap();
+        assert_eq!(ms.wins, 1);
+        assert_eq!(ms.plays, 2);
+    }
+
+    #[test]
+    fn merge_ignores_stats_that_only_exist_in_other() {
+        let m = Play(Black, 1, 1);
+        let moves = vec!();
+        let mut stats = MoveStats::new(&moves, Black);
+        let moves2 = vec!(m);
+        let mut other = MoveStats::new(&moves2, Black);
+        other.record_loss(&m);
+        stats.merge(&other);
+        assert!(!stats.stats.get(&m).is_some());
+    }
+
 }
 
 mod move_stat {
@@ -115,4 +141,16 @@ mod move_stat {
         assert_eq!(ms.win_ratio(), 0f32);
     }
 
+    #[test]
+    fn merge_adds_the_plays_and_wins_of_other() {
+        let mut ms = MoveStat::new();
+        let mut other = MoveStat::new();
+        ms.wins = 1;
+        ms.plays = 1;
+        other.wins = 1;
+        other.plays = 2;
+        ms.merge(&other);
+        assert_eq!(2, ms.wins);
+        assert_eq!(3, ms.plays);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ use version::version;
 use getopts::Options;
 use std::ascii::OwnedAsciiExt;
 use std::env::args;
-use std::os::num_cpus;
 
 macro_rules! log(
     ($($arg:tt)*) => (
@@ -77,7 +76,7 @@ pub fn main() {
     let args : Vec<String> = args().collect();
     opts.optopt("e", "engine", "select an engine (defaults to amaf)", "amaf|mc|random");
     opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
-    opts.optopt("t", "threads", format!("number of threads to use (defaults to {})", num_cpus()).as_slice(), "NUM");
+    opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
     opts.optflag("h", "help", "print this help menu");
     opts.optflag("v", "version", "print the version number");
 
@@ -99,10 +98,10 @@ pub fn main() {
         Some(s) => {
             match s.parse::<usize>() {
                 Ok(n)  => n,
-                Err(_) => num_cpus()
+                Err(_) => 1
             }
         },
-        None    => num_cpus()
+        None => 1
     };
     let engine_arg = matches.opt_str("e").map(|s| s.into_ascii_lowercase());
     let engine: Box<Engine> = match engine_arg {


### PR DESCRIPTION
I started working on using all cores for the playouts. This is what I've come up with so far. Currently it's still a bit slow (i.e. only a 4.5x speedup compared to the previous version with 8 threads), but my main problem is that the `mc_gen_move` function is now becoming quite big. I have a bit of a problem splitting stuff up into smaller functions as when I'm in the other threads I can't just call functions that are defined on `self`. Maybe I need to define functions without `self` as the first parameter, but then they're a bit cumbersome to call as I have to prepend `McEngine` everywhere. Tips on that are very welcome.

The following things besides this that need to be changed before this can be merged are:

1. Make the thread number configurable from the command line
1. Find a better way to parallelise the computation. Sending each playout to the main thread from the worker threads is probably quite a bit of overhead. It probably makes more sense to run `N` playouts in each worker and send back the resulting `MoveStats` instead and only merge them in the main engine thread.