### PR TITLE
Down to 37 warnings on build, even less on test

### DIFF
--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -1,6 +1,7 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014-2015 Urban Hafner, Thomas Poinsot                     *
+ * Copyright 2014 Urban Hafner, Thomas Poinsot                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,10 +21,10 @@
  ************************************************************************/
 
 #![cfg(test)]
+#![allow(unused_must_use)]
 
 use board::Black;
 use board::Board;
-use board::Chain;
 use board::Coord;
 use board::Empty;
 use board::IllegalMove;

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -25,7 +25,6 @@ use engine::Engine;
 use game::Game;
 use timer::Timer;
 
-use std::old_io::stdio::stderr;
 use std::old_io::timer::sleep;
 use std::sync::mpsc::channel;
 use std::thread;

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,6 +20,7 @@
  ************************************************************************/
 
 #![cfg(test)]
+#![allow(unused_must_use)]
 
 use board::Color;
 use board::Move;

--- a/src/engine/move_stats/test.rs
+++ b/src/engine/move_stats/test.rs
@@ -1,6 +1,7 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014-2015 Urban Hafner, Thomas Poinsot                     *
+ * Copyright 2014 Urban Hafner, Thomas Poinsot                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -36,7 +37,7 @@ mod move_stats {
     fn returns_pass_as_best_move_by_default() {
         let moves = vec!();
         let stats = MoveStats::new(&moves, Black);
-        let (m, ms) = stats.best();
+        let (m, _) = stats.best();
         assert_eq!(Pass(Black), m);
     }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,7 +1,7 @@
 /************************************************************************
  *                                                                      *
  * Copyright 2014 Urban Hafner, Thomas Poinsot                          *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -25,7 +25,6 @@ use board::Color;
 use board::Coord;
 use board::IllegalMove;
 use board::Move;
-use board::Play;
 use ruleset::Ruleset;
 use score::Score;
 use self::zobrist_hash_table::ZobristHashTable;

--- a/src/game/test/mod.rs
+++ b/src/game/test/mod.rs
@@ -1,7 +1,7 @@
 /************************************************************************
  *                                                                      *
  * Copyright 2014 Thomas Poinsot, Urban Hafner                          *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -31,7 +31,6 @@ use board::White;
 use game::Game;
 use ruleset::KgsChinese;
 use ruleset::Minimal;
-use super::Info;
 
 mod ko;
 
@@ -66,7 +65,7 @@ fn catch_suicide_moves_in_chinese() {
 
     match play {
         Err(e) => assert_eq!(e, IllegalMove::SuicidePlay),
-        Ok(v)  => panic!("Expected Err!")
+        Ok(_)  => panic!("Expected Err!")
     }
 }
 

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -23,7 +23,6 @@
 #![cfg(test)]
 
 use engine::RandomEngine;
-use game::Info;
 use ruleset::Minimal;
 use super::Command;
 use super::GTPInterpreter;
@@ -31,55 +30,55 @@ use super::GTPInterpreter;
 #[test]
 fn loadsgf_wrong_file() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("loadsgf wrongfileactually\n");
+    interpreter.read("loadsgf wrongfileactually\n");
 }
 
 #[test]
 fn loadsgf_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("loadsgf\n");
+    interpreter.read("loadsgf\n");
 }
 
 #[test]
 fn time_left_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("time_left\n");
+    interpreter.read("time_left\n");
 }
 
 #[test]
 fn time_settings_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("time_settings\n");
+    interpreter.read("time_settings\n");
 }
 
 #[test]
 fn play_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("play\n");
+    interpreter.read("play\n");
 }
 
 #[test]
 fn genmove_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("genmove\n");
+    interpreter.read("genmove\n");
 }
 
 #[test]
 fn komi_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("komi\n");
+    interpreter.read("komi\n");
 }
 
 #[test]
 fn boardsize_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("boardsize\n");
+    interpreter.read("boardsize\n");
 }
 
 #[test]
 fn known_command_one_argument() {
     let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
-    let error = interpreter.read("known_command\n");
+    interpreter.read("known_command\n");
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ mod sgf;
 mod timer;
 mod version;
 
-fn main() {
+pub fn main() {
     let mut opts = Options::new();
     let args : Vec<String> = args().collect();
     opts.optopt("e", "engine", "select an engine (defaults to amaf)", "amaf|mc|random");

--- a/src/score/test.rs
+++ b/src/score/test.rs
@@ -1,6 +1,7 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014-2015 Urban Hafner                                     *
+ * Copyright 2014 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -18,7 +19,9 @@
  * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
  *                                                                      *
  ************************************************************************/
+
 #![cfg(test)]
+#![allow(unused_must_use)]
 
 use board::Black;
 use board::Board;

--- a/src/sgf/parser.rs
+++ b/src/sgf/parser.rs
@@ -100,7 +100,7 @@ impl Parser {
     		Ok(mut file) => {
 		        let mut contents = String::new();
                 match file.read_to_string(&mut contents) {
-                	Ok(result) => Ok(Parser::new(contents)),
+                	Ok(_) => Ok(Parser::new(contents)),
                 	Err(e) => Err(e)
             	}
 			},

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner, Thomas Poinsot                          *
+ * Copyright 2015 Urban Hafner, Thomas Poinsot, Igor Polyakov           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -186,6 +186,7 @@ impl Timer {
         self.byo_stones_left = stones;
     }
 
+    #[allow(non_snake_case)]
     fn C(&self) -> f32 {
         0.5
     }

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Urban Hafner, Igor Polyakov                           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -22,7 +22,6 @@
 #![cfg(test)]
 
 use game::Info;
-use super::Clock;
 use super::Timer;
 
 use std::old_io::timer::sleep;


### PR DESCRIPTION
I think we can turn off some warnings on test because failing tests are fine - they are not what we use in production.

Question: should we switch over to using the production APIs and just ignoring results in tests? Because I can do this and save some build warnings.