### PR TITLE
Try excluding external crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ after_success: |
   make &&
   sudo make install &&
   cd ../.. &&
-  kcov --coveralls-id=$TRAVIS_JOB_ID target/kcov target/debug/iomrascalai-*
+  kcov --exclude-pattern=/.cargo --coveralls-id=$TRAVIS_JOB_ID target/kcov target/debug/iomrascalai-*
 
 notifications:
   webhooks:


### PR DESCRIPTION
Fixes the coverage reporting and now excludes code from external crates.