### PR TITLE
Allow turning off debug message to stderr

### DIFF
--- a/bin/play-brown
+++ b/bin/play-brown
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 BROWN="brown"
-IOMRASCALAI="./target/release/iomrascalai -e $1"
+IOMRASCALAI="./target/release/iomrascalai -e $1 -l"
 SIZE=9
 TIME="5m"
 

--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-IOMRASCALAI="./target/release/iomrascalai -e $1 -t 8"
+IOMRASCALAI="./target/release/iomrascalai -e $1 -t 8 -l"
 SIZE=9
 TIME="5m"
 

--- a/bin/play-self
+++ b/bin/play-self
@@ -7,8 +7,8 @@ set -ex
 
 cargo build --release
 
-IOMRASCALAIMC="./target/release/iomrascalai -e mc -t 8"
-IOMRASCALAIAMAF="./target/release/iomrascalai -e amaf -t 8"
+IOMRASCALAIMC="./target/release/iomrascalai -e mc -t 8 -l"
+IOMRASCALAIAMAF="./target/release/iomrascalai -e amaf -t 8 -l"
 SIZE=9
 TIME="5m"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@
  *                                                                      *
  ************************************************************************/
 
+use ruleset::Minimal;
 use ruleset::Ruleset;
 
 #[derive(Copy)]
@@ -26,4 +27,16 @@ pub struct Config {
     pub log: bool,
     pub ruleset: Ruleset,
     pub threads: usize,
+}
+
+impl Config {
+
+    pub fn default() -> Config {
+        Config {
+            log: false,
+            ruleset: Minimal,
+            threads: 1,
+        }
+    }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014 Urban Hafner                                          *
- * Copyright 2015 Urban Hafner, Thomas Poinsot                          *
+ * Copyright 2015 Urban Hafner                                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,45 +19,11 @@
  *                                                                      *
  ************************************************************************/
 
-use board::Color;
-use board::Move;
-use config::Config;
-use game::Game;
-use playout::Playout;
-use super::Engine;
-use super::McEngine;
-use super::MoveStats;
+use ruleset::Ruleset;
 
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::Sender;
-
-pub struct SimpleMcEngine {
-    config: Config
-}
-
-impl SimpleMcEngine {
-
-    pub fn new(config: Config) -> SimpleMcEngine {
-        SimpleMcEngine { config: config }
-    }
-
-}
-
-impl Engine for SimpleMcEngine {
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(self.config, color, game, sender, receiver);
-    }
-}
-
-impl McEngine for SimpleMcEngine {
-
-    fn record_playout(stats: &mut MoveStats, playout: &Playout, won: bool) {
-        let m = playout.moves()[0];
-        if won {
-            stats.record_win(&m);
-        } else {
-            stats.record_loss(&m);
-        }
-    }
-
+#[derive(Copy)]
+pub struct Config {
+    pub log: bool,
+    pub ruleset: Ruleset,
+    pub threads: usize,
 }

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -21,6 +21,7 @@
 
 use board::Color;
 use board::Move;
+use config::Config;
 use engine::Engine;
 use game::Game;
 use timer::Timer;
@@ -33,13 +34,15 @@ use std::time::duration::Duration;
 mod test;
 
 pub struct EngineController<'a> {
+    config: Config,
     engine: Box<Engine + 'a>,
 }
 
 impl<'a> EngineController<'a> {
 
-    pub fn new<'b>(engine: Box<Engine + 'b>) -> EngineController<'b> {
+    pub fn new<'b>(config: Config, engine: Box<Engine + 'b>) -> EngineController<'b> {
         EngineController {
+            config: config,
             engine: engine,
         }
     }
@@ -70,7 +73,9 @@ impl<'a> EngineController<'a> {
     fn budget(&self, timer: &mut Timer, game: &Game) -> i64 {
         timer.start();
         let budget = timer.budget(game);
-        log!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left());
+        if self.config.log {
+            log!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left());
+        }
         budget
     }
 

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -25,6 +25,7 @@
 use board::Color;
 use board::Move;
 use board::Pass;
+use config::Config;
 use engine::Engine;
 use game::Game;
 use ruleset::Minimal;
@@ -60,7 +61,7 @@ fn the_engine_can_use_less_time_than_allocated() {
     let mut timer = Timer::new();
     let budget = timer.budget(&game);
     let engine = Box::new(EarlyReturnEngine::new());
-    let mut controller = EngineController::new(engine);
+    let mut controller = EngineController::new(Config::default(), engine);
     let start_time = PreciseTime::now();
     let m = controller.run_and_return_move(color, &game, &mut timer);
     let elapsed_time = start_time.to(PreciseTime::now()).num_milliseconds();
@@ -96,7 +97,7 @@ fn the_controller_asks_the_engine_for_a_move_when_the_time_is_up() {
     timer.setup(1, 0, 0);
     let budget = timer.budget(&game);
     let engine = Box::new(WaitingEngine::new());
-    let mut controller = EngineController::new(engine);
+    let mut controller = EngineController::new(Config::default(), engine);
     let start_time = PreciseTime::now();
     let m = controller.run_and_return_move(color, &game, &mut timer);
     let elapsed_time = start_time.to(PreciseTime::now()).num_milliseconds();

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -22,6 +22,7 @@
 
 use board::Color;
 use board::Move;
+use config::Config;
 use game::Game;
 use playout::Playout;
 use super::Engine;
@@ -32,13 +33,13 @@ use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct AmafMcEngine {
-    threads: usize
+    config: Config
 }
 
 impl AmafMcEngine {
 
-    pub fn new(threads: usize) -> AmafMcEngine {
-        AmafMcEngine { threads: threads }
+    pub fn new(config: Config) -> AmafMcEngine {
+        AmafMcEngine { config: config }
     }
 
 }
@@ -46,7 +47,7 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<AmafMcEngine>(self.threads, color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(self.config, color, game, sender, receiver);
     }
 
 }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -29,6 +29,7 @@ use board::Color;
 use board::Move;
 use board::Pass;
 use board::Resign;
+use config::Config;
 use game::Game;
 use playout::Playout;
 
@@ -48,17 +49,19 @@ pub trait McEngine: MarkerTrait {
 
 }
 
-fn gen_move<T: McEngine>(threads: usize, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+fn gen_move<T: McEngine>(config: Config, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
     let moves = game.legal_moves_without_eyes();
     if moves.is_empty() {
-        log!("No moves to simulate!");
+        if config.log {
+            log!("No moves to simulate!");
+        }
         sender.send(Pass(color));
         return;
     }
     let mut stats = MoveStats::new(&moves, color);
     let mut counter = 0;
     let (send_result, receive_result) = channel::<(MoveStats, usize)>();
-    let (guards, halt_senders) = spin_up::<T>(color, threads, &moves, game, send_result);
+    let (guards, halt_senders) = spin_up::<T>(color, config.threads, &moves, game, send_result);
     loop {
         select!(
             result = receive_result.recv() => {
@@ -67,29 +70,32 @@ fn gen_move<T: McEngine>(threads: usize, color: Color, game: &Game, sender: Send
                 counter += count;
             },
             _ = receiver.recv() => {
-                log!("{} simulations", counter);
-                finish(color, game, stats, sender, halt_senders);
+                let msg = finish(color, game, stats, sender, halt_senders);
+                if config.log {
+                    log!("{} simulations", counter);
+                    log!("{}", msg);
+                }
                 break;
             }
             )
     }
 }
 
-fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) {
+fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, halt_senders: Vec<Sender<()>>) -> String {
+    for halt_sender in halt_senders.iter() {
+        halt_sender.send(());
+    }
     if stats.all_losses() {
-        log!("All simulations were losses");
         if game.winner() == color {
             sender.send(Pass(color));
         } else {
             sender.send(Resign(color));
         }
+        String::from_str("All simulations were losses")
     } else {
         let (m, s) = stats.best();
-        log!("Returning the best move ({}% wins)", s.win_ratio()*100.0);
         sender.send(m);
-    }
-    for halt_sender in halt_senders.iter() {
-        halt_sender.send(());
+        format!("Returning the best move ({}% wins)", s.win_ratio()*100.0)
     }
 }
 

--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -20,8 +20,8 @@
  *                                                                      *
  ************************************************************************/
 
+use config::Config;
 use engine::Engine;
-use ruleset::Ruleset;
 use super::Command;
 use super::GTPInterpreter;
 use version;
@@ -31,12 +31,12 @@ use std::old_io::stdio::stdin;
 pub struct Driver;
 
 impl Driver {
-    pub fn new(ruleset: Ruleset, engine: Box<Engine>) {
+    pub fn new(config: Config, engine: Box<Engine>) {
         let engine_name = "Iomrascalai";
         let engine_version = version::version();
         let protocol_version = "2";
 
-        let mut interpreter = GTPInterpreter::new(ruleset, engine);
+        let mut interpreter = GTPInterpreter::new(config, engine);
         let mut reader = stdin();
 
         loop {

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -22,14 +22,14 @@
 
 #![cfg(test)]
 
+use config::Config;
 use engine::RandomEngine;
-use ruleset::Minimal;
 use super::Command;
 use super::GTPInterpreter;
 
 #[test]
 fn empty_string() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     let command = interpreter.read("");
     match command {
     	Command::Empty => (),
@@ -39,61 +39,61 @@ fn empty_string() {
 
 #[test]
 fn loadsgf_wrong_file() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf wrongfileactually\n");
 }
 
 #[test]
 fn loadsgf_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf\n");
 }
 
 #[test]
 fn time_left_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("time_left\n");
 }
 
 #[test]
 fn time_settings_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("time_settings\n");
 }
 
 #[test]
 fn play_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("play\n");
 }
 
 #[test]
 fn genmove_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("genmove\n");
 }
 
 #[test]
 fn komi_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("komi\n");
 }
 
 #[test]
 fn boardsize_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("boardsize\n");
 }
 
 #[test]
 fn known_command_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("known_command\n");
 }
 
 #[test]
 fn no_newline_at_end_of_list_commands() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     let commands    = interpreter.read("list_commands\n");
     let expected    = "boardsize\nclear_board\nfinal_score\ngenmove\nknown_command\nkomi\nlist_commands\nloadsgf\nname\nplay\nprotocol_version\nquit\nshowboard\ntime_left\ntime_settings\nversion";
     match commands {
@@ -104,7 +104,7 @@ fn no_newline_at_end_of_list_commands() {
 
 #[test]
 fn boardsize_sets_the_correct_size() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     assert_eq!(19, interpreter.game.size());
     interpreter.read("boardsize 9\n");
     assert_eq!(9, interpreter.game.size());
@@ -112,7 +112,7 @@ fn boardsize_sets_the_correct_size() {
 
 #[test]
 fn boardsize_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("boardsize 9\n");
     assert_eq!(0, interpreter.game.move_number());
@@ -120,21 +120,21 @@ fn boardsize_resets_the_board() {
 
 #[test]
 fn play_plays_a_move() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     assert_eq!(1, interpreter.game.move_number());
 }
 
 #[test]
 fn sets_the_komi() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("komi 10\n");
     assert_eq!(10.0, interpreter.komi());
 }
 
 #[test]
 fn sets_the_time() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("time_settings 30 20 10\n");
     assert_eq!(30_000, interpreter.main_time());
     assert_eq!(20_000, interpreter.byo_time());
@@ -143,7 +143,7 @@ fn sets_the_time() {
 
 #[test]
 fn clear_board_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("clear_board\n");
     assert_eq!(0, interpreter.game.move_number());
@@ -151,7 +151,7 @@ fn clear_board_resets_the_board() {
 
 #[test]
 fn final_score_no_move() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     match interpreter.read("final_score\n") {
         Command::FinalScore(score) => assert_eq!("W+6.5", score.as_slice()),
         _                          => panic!("FinalScore expected!")
@@ -160,7 +160,7 @@ fn final_score_no_move() {
 
 #[test]
 fn final_score_one_move() {
-    let mut interpreter = GTPInterpreter::new(Minimal, Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("boardsize 4\n");
     interpreter.read("play b c2\n");
     match interpreter.read("final_score\n") {


### PR DESCRIPTION
Adds a `-l` or `--log` command line switch to turn on/off the logging to stderr. I have the feeling that these messages are what make the CGOS client crash from time to time.