### PR TITLE
Fix playout length bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,14 +6,14 @@ dependencies = [
  "rand 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "strenum 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -71,7 +71,7 @@ name = "time"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["Urban Hafner <contact@urbanhafner.com>",
 homepage = "https://github.com/ujh/iomrascalai"
 repository = "https://github.com/ujh/iomrascalai"
 license = "GPL-3.0+"
-license-file = "LICENSE"
 
 [dependencies]
 

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -39,7 +39,7 @@ impl Playout {
         let mut played_moves = Vec::new();
         board.play(*initial_move);
         played_moves.push(*initial_move);
-        let max_moves = board.size() * board.size() * 3;
+        let max_moves = Playout::max_moves(board.size());
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
             let moves = board.legal_moves_without_eyes();
@@ -57,6 +57,10 @@ impl Playout {
             moves: played_moves,
             winner: board.winner(),
         }
+    }
+
+    pub fn max_moves(size: u8) -> usize {
+        size as usize * size as usize * 3
     }
 
     pub fn moves(&self) -> &Vec<Move> {

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -37,6 +37,12 @@ fn should_add_the_passed_moves_as_the_first_move() {
     assert_eq!(Play(Black, 1, 1), playout.moves()[0]);
 }
 
+#[test]
+fn max_moves() {
+    let game = Game::new(19, 6.5, KgsChinese);
+    let board = game.board();
+    assert_eq!(1083, Playout::max_moves(19));
+}
 
 #[bench]
 fn bench_9x9_playout_speed(b: &mut Bencher) {


### PR DESCRIPTION
Due to the board size being `u8` everywhere, the calculation for the maximum number of moves produced an (unchecked) overflow for 19x19. This is the quick fix, but [using usize for the board size](https://trello.com/c/WP8xhdMH) is the proper fix.