### PR TITLE
Four kinds of playouts

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -19,6 +19,7 @@
  * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
  *                                                                      *
  ************************************************************************/
+
 pub use self::Color::Black;
 pub use self::Color::Empty;
 pub use self::Color::White;
@@ -28,22 +29,22 @@ pub use self::movement::Move;
 pub use self::movement::Pass;
 pub use self::movement::Play;
 pub use self::movement::Resign;
-use rand::{Rng, XorShiftRng};
 use ruleset::Ruleset;
 use score::Score;
 use self::point::Point;
 
-use std::sync::Arc;
+use rand::Rng;
+use rand::XorShiftRng;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
-use std::vec::Vec;
+use std::sync::Arc;
 
-mod test;
 mod chain;
 mod coord;
 mod movement;
 mod point;
+mod test;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum IllegalMove {
@@ -262,7 +263,7 @@ impl Board {
                 .collect()
         }
     }
-    
+
     pub fn playout_move(&self, rng: &mut XorShiftRng) -> Move {
             let color = self.next_player();
             let vacant = self.vacant();
@@ -276,14 +277,14 @@ impl Board {
                         let random_play = Play(color, random_vacant.col, random_vacant.row);
                         if !self.is_eye(&random_vacant, color) && self.playout_legal_move(random_play) {
                             return random_play;
-                        } 
+                        }
                     }
                 } else {
                     let color = self.next_player();
                     Pass(color)
                 }
 	}
-    
+
     fn playout_legal_move(&self, m: Move) -> bool {
     	        // Can't play on a Ko point
         if self.ko.is_some() && m.coord() == self.ko.unwrap() {
@@ -315,10 +316,10 @@ impl Board {
                 }
             }
         }
-        
+
         true
 	}
-    
+
     //#[inline(never)] //turn off for profiling
     pub fn legal_moves_without_eyes(&self) -> Vec<Move> {
         self.legal_moves_without_superko_check()

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -264,27 +264,6 @@ impl Board {
         }
     }
 
-    pub fn playout_move(&self, rng: &mut XorShiftRng) -> Move {
-            let color = self.next_player();
-            let vacant = self.vacant();
-            if vacant
-                .iter()
-                .map(|coord| Play(color, coord.col, coord.row))
-                .any(|m| !self.is_eye(&m.coord(), *m.color()) && self.is_legal(m).is_ok() ) {
-                    //while loop testing all vacant spots
-                    loop {
-                        let random_vacant = vacant[rng.gen::<usize>() % vacant.len()];
-                        let random_play = Play(color, random_vacant.col, random_vacant.row);
-                        if !self.is_eye(&random_vacant, color) && self.is_legal(random_play).is_ok() {
-                            return random_play;
-                        }
-                    }
-                } else {
-                    let color = self.next_player();
-                    Pass(color)
-                }
-	}
-
     //#[inline(never)] //turn off for profiling
     pub fn legal_moves_without_eyes(&self) -> Vec<Move> {
         self.legal_moves_without_superko_check()

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -270,12 +270,12 @@ impl Board {
             if vacant
                 .iter()
                 .map(|coord| Play(color, coord.col, coord.row))
-                .any(|m| !self.is_eye(&m.coord(), *m.color()) && self.playout_legal_move(m) ) {
+                .any(|m| !self.is_eye(&m.coord(), *m.color()) && self.is_legal(m).is_ok() ) {
                     //while loop testing all vacant spots
                     loop {
                         let random_vacant = vacant[rng.gen::<usize>() % vacant.len()];
                         let random_play = Play(color, random_vacant.col, random_vacant.row);
-                        if !self.is_eye(&random_vacant, color) && self.playout_legal_move(random_play) {
+                        if !self.is_eye(&random_vacant, color) && self.is_legal(random_play).is_ok() {
                             return random_play;
                         }
                     }
@@ -283,41 +283,6 @@ impl Board {
                     let color = self.next_player();
                     Pass(color)
                 }
-	}
-
-    fn playout_legal_move(&self, m: Move) -> bool {
-    	        // Can't play on a Ko point
-        if self.ko.is_some() && m.coord() == self.ko.unwrap() {
-            if self.neighbours(m.coord()) //neighbours of the coordinate of the ko point
-                .iter()
-                .filter(|&c| self.color(c) == m.color().opposite()) //accept coordinates of opposite stones
-                .map(|&c| self.get_chain(c).unwrap()) //get the chain of those opposite stones
-                .any(|chain| chain.liberties().len() == 1 && chain.coords().len() == 1) { //if any of them has one liberty and one stone
-                    return false;
-                }
-        }
-        // Can't play suicide move
-        if !self.ruleset.suicide_allowed() {
-            // All neighbours must be occupied
-            if self.neighbours(m.coord()).iter().all(|c| self.color(c) != Empty) {
-                // A move is a suicide move if all of the opposing,
-                // neighbouring chain has more than one liberty and all of
-                // our own chains have only one liberty.
-                let enemy_chains_with_other_libs = self.neighbours(m.coord())
-                    .iter()
-                    .filter(|&c| self.color(c) == m.color().opposite())
-                    .all(|&c| self.get_chain(c).unwrap().liberties().len() > 1);
-                let own_chains_without_other_libs = self.neighbours(m.coord())
-                    .iter()
-                    .filter(|&c| self.color(c) == *m.color())
-                    .all(|&c| self.get_chain(c).unwrap().liberties().len() <= 1);
-                if enemy_chains_with_other_libs && own_chains_without_other_libs {
-                    return false;
-                }
-            }
-        }
-
-        true
 	}
 
     //#[inline(never)] //turn off for profiling

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -22,7 +22,6 @@
 
 #![cfg(test)]
 #![allow(unused_must_use)]
-use std::path::Path;
 use board::Black;
 use board::Board;
 use board::Coord;
@@ -36,8 +35,9 @@ use ruleset::AnySizeTrompTaylor;
 use ruleset::KgsChinese;
 use ruleset::Minimal;
 use sgf::Parser;
-use rand::{Rng, weak_rng};
-use test::Bencher;
+
+use rand::weak_rng;
+use std::path::Path;
 
 mod diagonals;
 mod eye;
@@ -498,11 +498,11 @@ fn adv_stones_removed_only_contains_each_coord_once() {
 #[test]
 fn random_playout_moves_should_be_legal() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/recapture-but-not-ko.sgf"));
-    let game   = parser.game().unwrap();
-    let mut board  = game.board();
+    let game = parser.game().unwrap();
+    let board = game.board();
     let mut rng = weak_rng();
-    for i in 0..10 {
+    for _ in 0..10 {
     	let m = board.playout_move(&mut rng);
     	assert!(board.is_legal(m).is_ok());
-	}
+    }
 }

--- a/src/board/test/mod.rs
+++ b/src/board/test/mod.rs
@@ -494,15 +494,3 @@ fn adv_stones_removed_only_contains_each_coord_once() {
     removed_coords.dedup();
     assert_eq!(removed_coords.len(), board.adv_stones_removed().len());
 }
-
-#[test]
-fn random_playout_moves_should_be_legal() {
-    let parser = Parser::from_path(Path::new("fixtures/sgf/recapture-but-not-ko.sgf"));
-    let game = parser.game().unwrap();
-    let board = game.board();
-    let mut rng = weak_rng();
-    for _ in 0..10 {
-    	let m = board.playout_move(&mut rng);
-    	assert!(board.is_legal(m).is_ok());
-    }
-}

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,8 +24,6 @@ use playout::SimplePlayout;
 use ruleset::Minimal;
 use ruleset::Ruleset;
 
-use std::sync::Arc;
-
 pub struct Config {
     pub log: bool,
     pub playout: Box<Playout>,

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -28,6 +28,7 @@ use timer::Timer;
 use std::old_io::Writer;
 
 use std::old_io::timer::sleep;
+use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread;
 use std::time::duration::Duration;
@@ -35,13 +36,13 @@ use std::time::duration::Duration;
 mod test;
 
 pub struct EngineController<'a> {
-    config: Config,
+    config: Arc<Config>,
     engine: Box<Engine + 'a>,
 }
 
 impl<'a> EngineController<'a> {
 
-    pub fn new<'b>(config: Config, engine: Box<Engine + 'b>) -> EngineController<'b> {
+    pub fn new<'b>(config: Arc<Config>, engine: Box<Engine + 'b>) -> EngineController<'b> {
         EngineController {
             config: config,
             engine: engine,

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -32,6 +32,7 @@ use ruleset::Minimal;
 use super::EngineController;
 use timer::Timer;
 
+use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use time::PreciseTime;
@@ -61,7 +62,7 @@ fn the_engine_can_use_less_time_than_allocated() {
     let mut timer = Timer::new();
     let budget = timer.budget(&game);
     let engine = Box::new(EarlyReturnEngine::new());
-    let mut controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(Arc::new(Config::default()), engine);
     let start_time = PreciseTime::now();
     let m = controller.run_and_return_move(color, &game, &mut timer);
     let elapsed_time = start_time.to(PreciseTime::now()).num_milliseconds();
@@ -97,7 +98,7 @@ fn the_controller_asks_the_engine_for_a_move_when_the_time_is_up() {
     timer.setup(1, 0, 0);
     let budget = timer.budget(&game);
     let engine = Box::new(WaitingEngine::new());
-    let mut controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(Arc::new(Config::default()), engine);
     let start_time = PreciseTime::now();
     let m = controller.run_and_return_move(color, &game, &mut timer);
     let elapsed_time = start_time.to(PreciseTime::now()).num_milliseconds();

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -29,16 +29,17 @@ use super::Engine;
 use super::McEngine;
 use super::MoveStats;
 
+use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct AmafMcEngine {
-    config: Config
+    config: Arc<Config>
 }
 
 impl AmafMcEngine {
 
-    pub fn new(config: Config) -> AmafMcEngine {
+    pub fn new(config: Arc<Config>) -> AmafMcEngine {
         AmafMcEngine { config: config }
     }
 
@@ -47,7 +48,7 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<AmafMcEngine>(self.config, color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(self.config.clone(), color, game, sender, receiver);
     }
 
 }

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -51,6 +51,10 @@ impl Engine for AmafMcEngine {
         super::gen_move::<AmafMcEngine>(self.config.clone(), color, game, sender, receiver);
     }
 
+    fn engine_type(&self) -> &'static str {
+        "amaf"
+    }
+
 }
 
 impl McEngine for AmafMcEngine {

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -24,7 +24,7 @@ use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
-use playout::Playout;
+use playout::PlayoutResult;
 use super::Engine;
 use super::McEngine;
 use super::MoveStats;
@@ -54,7 +54,7 @@ impl Engine for AmafMcEngine {
 
 impl McEngine for AmafMcEngine {
 
-    fn record_playout(stats: &mut MoveStats, playout: &Playout, won: bool) {
+    fn record_playout(stats: &mut MoveStats, playout: &PlayoutResult, won: bool) {
         for m in playout.moves().iter() {
             if won {
                 stats.record_win(&m);

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -125,7 +125,7 @@ fn spin_up_worker<'a, T: McEngine>(color: Color, recv_halt: Receiver<()>, moves:
         loop {
             for _ in 0..runs {
                 let m = moves[rng.gen::<usize>() % moves.len()];
-                let playout_result = config.playout.run(&board, &m, &mut rng);
+                let playout_result = config.playout.run(&board, &m);
                 let winner = playout_result.winner();
                 T::record_playout(&mut stats, &playout_result, winner == color);
             }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -52,7 +52,7 @@ pub trait McEngine: MarkerTrait {
 
 }
 
-fn gen_move<T: McEngine>(config: Config, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+fn gen_move<T: McEngine>(config: Arc<Config>, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
     let moves = game.legal_moves_without_eyes();
     if moves.is_empty() {
         if config.log {
@@ -64,8 +64,7 @@ fn gen_move<T: McEngine>(config: Config, color: Color, game: &Game, sender: Send
     let mut stats = MoveStats::new(&moves, color);
     let mut counter = 0;
     let (send_result, receive_result) = channel::<(MoveStats, usize)>();
-    let playout = Arc::new(Playout::new());
-    let (guards, halt_senders) = spin_up::<T>(color, config.threads, &moves, game, playout, send_result);
+    let (guards, halt_senders) = spin_up::<T>(color, config.clone(), &moves, game, send_result);
     loop {
         select!(
             result = receive_result.recv() => {
@@ -103,20 +102,21 @@ fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, hal
     }
 }
 
-fn spin_up<'a, T: McEngine>(color: Color, threads: usize, moves: &'a Vec<Move>, game: &Game, playout: Arc<Playout>, send_result: Sender<(MoveStats<'a>, usize)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {
+fn spin_up<'a, T: McEngine>(color: Color, config: Arc<Config>, moves: &'a Vec<Move>, game: &Game, send_result: Sender<(MoveStats<'a>, usize)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {
     let mut guards = Vec::new();
     let mut halt_senders = Vec::new();
-    for _ in 0..threads {
+    for _ in 0..config.threads {
         let (send_halt, receive_halt) = channel::<()>();
         halt_senders.push(send_halt);
         let send_result = send_result.clone();
-        let guard = spin_up_worker::<T>(color, receive_halt, moves, game.board(), playout.clone(), send_result);
+        let config = config.clone();
+        let guard = spin_up_worker::<T>(color, receive_halt, moves, game.board(), config, send_result);
         guards.push(guard);
     }
     (guards, halt_senders)
 }
 
-fn spin_up_worker<'a, T: McEngine>(color: Color, recv_halt: Receiver<()>, moves: &'a Vec<Move>, board: Board, playout: Arc<Playout>, send_result: Sender<(MoveStats<'a>, usize)>) -> thread::JoinGuard<'a, ()> {
+fn spin_up_worker<'a, T: McEngine>(color: Color, recv_halt: Receiver<()>, moves: &'a Vec<Move>, board: Board, config: Arc<Config>, send_result: Sender<(MoveStats<'a>, usize)>) -> thread::JoinGuard<'a, ()> {
     thread::scoped(move || {
         let runs = 100;
         let mut rng = weak_rng();
@@ -125,6 +125,7 @@ fn spin_up_worker<'a, T: McEngine>(color: Color, recv_halt: Receiver<()>, moves:
             for _ in 0..runs {
                 let m = moves[rng.gen::<usize>() % moves.len()];
                 let playout_result = playout.run(&board, &m, &mut rng);
+                let playout_result = config.playout.run(&board, &m, &mut rng);
                 let winner = playout_result.winner();
                 T::record_playout(&mut stats, &playout_result, winner == color);
             }

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -33,10 +33,11 @@ use config::Config;
 use game::Game;
 use playout::Playout;
 use playout::PlayoutResult;
-use std::old_io::Writer;
 
-use rand::{Rng, weak_rng};
+use rand::Rng;
+use rand::weak_rng;
 use std::marker::MarkerTrait;
+use std::old_io::Writer;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
@@ -124,7 +125,6 @@ fn spin_up_worker<'a, T: McEngine>(color: Color, recv_halt: Receiver<()>, moves:
         loop {
             for _ in 0..runs {
                 let m = moves[rng.gen::<usize>() % moves.len()];
-                let playout_result = playout.run(&board, &m, &mut rng);
                 let playout_result = config.playout.run(&board, &m, &mut rng);
                 let winner = playout_result.winner();
                 T::record_playout(&mut stats, &playout_result, winner == color);

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -29,16 +29,17 @@ use super::Engine;
 use super::McEngine;
 use super::MoveStats;
 
+use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct SimpleMcEngine {
-    config: Config
+    config: Arc<Config>
 }
 
 impl SimpleMcEngine {
 
-    pub fn new(config: Config) -> SimpleMcEngine {
+    pub fn new(config: Arc<Config>) -> SimpleMcEngine {
         SimpleMcEngine { config: config }
     }
 
@@ -46,7 +47,7 @@ impl SimpleMcEngine {
 
 impl Engine for SimpleMcEngine {
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(self.config, color, game, sender, receiver);
+        super::gen_move::<SimpleMcEngine>(self.config.clone(), color, game, sender, receiver);
     }
 }
 

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -24,7 +24,7 @@ use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
-use playout::Playout;
+use playout::PlayoutResult;
 use super::Engine;
 use super::McEngine;
 use super::MoveStats;
@@ -52,7 +52,7 @@ impl Engine for SimpleMcEngine {
 
 impl McEngine for SimpleMcEngine {
 
-    fn record_playout(stats: &mut MoveStats, playout: &Playout, won: bool) {
+    fn record_playout(stats: &mut MoveStats, playout: &PlayoutResult, won: bool) {
         let m = playout.moves()[0];
         if won {
             stats.record_win(&m);

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -39,10 +39,16 @@ impl RandomEngine {
 }
 
 impl Engine for RandomEngine {
+
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, _: Receiver<()>) {
         let mut moves = game.legal_moves();
         moves.push(Pass(color));
         let m = moves[random::<usize>() % moves.len()];
         sender.send(m);
     }
+
+    fn engine_type(&self) -> &'static str {
+        "random"
+    }
+
 }

--- a/src/engine/test.rs
+++ b/src/engine/test.rs
@@ -1,7 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2014 Urban Hafner                                          *
- * Copyright 2015 Urban Hafner, Thomas Poinsot                          *
+ * Copyright 2015 Urban Hafner                                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -20,52 +19,32 @@
  *                                                                      *
  ************************************************************************/
 
-use board::Color;
-use board::Move;
+#![cfg(test)]
+
 use config::Config;
-use game::Game;
-use playout::PlayoutResult;
-use super::Engine;
-use super::McEngine;
-use super::MoveStats;
 
 use std::sync::Arc;
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::Sender;
 
-pub struct SimpleMcEngine {
-    config: Arc<Config>
+#[test]
+fn factory_returns_amaf_by_default() {
+    let engine = super::factory(None, Arc::new(Config::default()));
+    assert_eq!("amaf", engine.engine_type());
 }
 
-impl SimpleMcEngine {
-
-    pub fn new(config: Arc<Config>) -> SimpleMcEngine {
-        SimpleMcEngine { config: config }
-    }
-
+#[test]
+fn factory_returns_random_engine_when_give_random() {
+    let engine = super::factory(Some(String::from_str("random")), Arc::new(Config::default()));
+    assert_eq!("random", engine.engine_type());
 }
 
-impl Engine for SimpleMcEngine {
-
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(self.config.clone(), color, game, sender, receiver);
-    }
-
-    fn engine_type(&self) -> &'static str {
-        "simple-mc"
-    }
-
+#[test]
+fn factory_returns_simple_mc_when_given_mc() {
+    let engine = super::factory(Some(String::from_str("mc")), Arc::new(Config::default()));
+    assert_eq!("simple-mc", engine.engine_type());
 }
 
-impl McEngine for SimpleMcEngine {
-
-    fn record_playout(stats: &mut MoveStats, playout: &PlayoutResult, won: bool) {
-        let m = playout.moves()[0];
-        if won {
-            stats.record_win(&m);
-        } else {
-            stats.record_loss(&m);
-        }
-    }
-
+#[test]
+fn factory_rutuyrns_amaf_for_any_other_string() {
+    let engine = super::factory(Some(String::from_str("foo")), Arc::new(Config::default()));
+    assert_eq!("amaf", engine.engine_type());
 }

--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -26,12 +26,13 @@ use super::Command;
 use super::GTPInterpreter;
 use version;
 
+use std::sync::Arc;
 use std::old_io::stdio::stdin;
 
 pub struct Driver;
 
 impl Driver {
-    pub fn new(config: Config, engine: Box<Engine>) {
+    pub fn new(config: Arc<Config>, engine: Box<Engine>) {
         let engine_name = "Iomrascalai";
         let engine_version = version::version();
         let protocol_version = "2";

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -33,6 +33,8 @@ use sgf::parser::Parser;
 use timer::Timer;
 use strenum::Strenum;
 
+use std::sync::Arc;
+
 pub mod driver;
 mod test;
 
@@ -81,19 +83,19 @@ pub enum Command {
 }
 
 pub struct GTPInterpreter<'a> {
-    config: Config,
+    config: Arc<Config>,
     controller: EngineController<'a>,
     game: Game,
     timer: Timer,
 }
 
 impl<'a> GTPInterpreter<'a> {
-    pub fn new<'b>(config: Config, engine: Box<Engine + 'b>) -> GTPInterpreter<'b> {
+    pub fn new<'b>(config: Arc<Config>, engine: Box<Engine + 'b>) -> GTPInterpreter<'b> {
         let komi      = 6.5;
         let boardsize = 19;
         GTPInterpreter {
-            config: config,
-            controller: EngineController::new(config, engine),
+            config: config.clone(),
+            controller: EngineController::new(config.clone(), engine),
             game: Game::new(boardsize, komi, config.ruleset),
             timer: Timer::new(),
         }

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -1,7 +1,7 @@
 /************************************************************************
  *                                                                      *
  * Copyright 2014 Urban Hafner                                          *
- * Copyright 2015 Thomas Poinsot, Igor Polyakov                         *
+ * Copyright 2015 Thomas Poinsot, Igor Polyakov, Urban Hafner           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -27,9 +27,11 @@ use engine::RandomEngine;
 use super::Command;
 use super::GTPInterpreter;
 
+use std::sync::Arc;
+
 #[test]
 fn empty_string() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     let command = interpreter.read("");
     match command {
     	Command::Empty => (),
@@ -39,61 +41,61 @@ fn empty_string() {
 
 #[test]
 fn loadsgf_wrong_file() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf wrongfileactually\n");
 }
 
 #[test]
 fn loadsgf_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf\n");
 }
 
 #[test]
 fn time_left_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("time_left\n");
 }
 
 #[test]
 fn time_settings_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("time_settings\n");
 }
 
 #[test]
 fn play_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("play\n");
 }
 
 #[test]
 fn genmove_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("genmove\n");
 }
 
 #[test]
 fn komi_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("komi\n");
 }
 
 #[test]
 fn boardsize_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("boardsize\n");
 }
 
 #[test]
 fn known_command_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("known_command\n");
 }
 
 #[test]
 fn no_newline_at_end_of_list_commands() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     let commands    = interpreter.read("list_commands\n");
     let expected    = "boardsize\nclear_board\nfinal_score\ngenmove\nknown_command\nkomi\nlist_commands\nloadsgf\nname\nplay\nprotocol_version\nquit\nshowboard\ntime_left\ntime_settings\nversion";
     match commands {
@@ -104,7 +106,7 @@ fn no_newline_at_end_of_list_commands() {
 
 #[test]
 fn boardsize_sets_the_correct_size() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     assert_eq!(19, interpreter.game.size());
     interpreter.read("boardsize 9\n");
     assert_eq!(9, interpreter.game.size());
@@ -112,7 +114,7 @@ fn boardsize_sets_the_correct_size() {
 
 #[test]
 fn boardsize_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("boardsize 9\n");
     assert_eq!(0, interpreter.game.move_number());
@@ -120,21 +122,21 @@ fn boardsize_resets_the_board() {
 
 #[test]
 fn play_plays_a_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     assert_eq!(1, interpreter.game.move_number());
 }
 
 #[test]
 fn sets_the_komi() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("komi 10\n");
     assert_eq!(10.0, interpreter.komi());
 }
 
 #[test]
 fn sets_the_time() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("time_settings 30 20 10\n");
     assert_eq!(30_000, interpreter.main_time());
     assert_eq!(20_000, interpreter.byo_time());
@@ -143,7 +145,7 @@ fn sets_the_time() {
 
 #[test]
 fn clear_board_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("clear_board\n");
     assert_eq!(0, interpreter.game.move_number());
@@ -151,7 +153,7 @@ fn clear_board_resets_the_board() {
 
 #[test]
 fn final_score_no_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     match interpreter.read("final_score\n") {
         Command::FinalScore(score) => assert_eq!("W+6.5", score.as_slice()),
         _                          => panic!("FinalScore expected!")
@@ -160,7 +162,7 @@ fn final_score_no_move() {
 
 #[test]
 fn final_score_one_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(Arc::new(Config::default()), Box::new(RandomEngine::new()));
     interpreter.read("boardsize 4\n");
     interpreter.read("play b c2\n");
     match interpreter.read("final_score\n") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,7 @@
  ************************************************************************/
 #![feature(collections)]
 #![feature(core)]
-#![feature(io)]
 #![feature(old_io)]
-#![feature(old_path)]
 #![feature(plugin)]
 #![feature(std_misc)]
 #![feature(test)]
@@ -39,14 +37,7 @@ extern crate time;
 #[macro_use(strenum)] extern crate strenum;
 
 use config::Config;
-use engine::AmafMcEngine;
-use engine::Engine;
-use engine::RandomEngine;
-use engine::SimpleMcEngine;
 use gtp::driver::Driver;
-use playout::NoEyesPlayout;
-use playout::Playout;
-use playout::SimplePlayout;
 use ruleset::KgsChinese;
 use ruleset::Ruleset;
 use version::version;

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,16 +123,6 @@ pub fn main() {
         ruleset: ruleset,
         threads: threads,
     });
-    let engine_arg = matches.opt_str("e").map(|s| s.into_ascii_lowercase());
-    let engine: Box<Engine> = match engine_arg {
-        Some(s) => {
-            match s.as_slice() {
-                "random" => Box::new(RandomEngine::new()),
-                "mc"     => Box::new(SimpleMcEngine::new(config.clone())),
-                _        => Box::new(AmafMcEngine::new(config.clone())),
-            }
-        },
-        None => Box::new(AmafMcEngine::new(config.clone()))
-    };
+    let engine = engine::factory(matches.opt_str("e"), config.clone());
     Driver::new(config.clone(), engine);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,15 +112,6 @@ pub fn main() {
         },
         None => 1
     };
-    let playout: Box<Playout> = match matches.opt_str("p") {
-        Some(s) => {
-            match s.as_slice() {
-                "simple" => Box::new(SimplePlayout::new()),
-                _ => Box::new(NoEyesPlayout::new()),
-            }
-        }
-        None => Box::new(NoEyesPlayout::new())
-    };
     let rules_arg = matches.opt_str("r").map(|s| s.into_ascii_lowercase());
     let ruleset = match rules_arg {
         Some(r) => Ruleset::from_string(r),
@@ -128,7 +119,7 @@ pub fn main() {
     };
     let config = Arc::new(Config {
         log: log,
-        playout: playout,
+        playout: playout::factory(matches.opt_str("p")),
         ruleset: ruleset,
         threads: threads,
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ pub fn main() {
     opts.optopt("e", "engine", "select an engine (defaults to amaf)", "amaf|mc|random");
     opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
     opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
-    opts.optopt("p", "playout", "type of playout to use (defaults to no-eyes)", "no-eyes|simple");
+    opts.optopt("p", "playout", "type of playout to use (defaults to no-eyes)", "no-eyes|no-eyes-with-pass|simple|simple-with-pass");
     opts.optflag("h", "help", "print this help menu");
     opts.optflag("v", "version", "print the version number");
     opts.optflag("l", "log", "log to stderr (defaults to false)");

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -19,6 +19,8 @@
  *                                                                      *
  ************************************************************************/
 
+pub use self::no_eyes::NoEyesPlayout;
+pub use self::simple::SimplePlayout;
 use board::Board;
 use board::Move;
 use board::Color;
@@ -26,17 +28,13 @@ use board::Pass;
 
 use rand::{Rng, XorShiftRng};
 
+mod no_eyes;
+mod simple;
 mod test;
 
-pub struct Playout;
+pub trait Playout: Sync + Send {
 
-impl Playout {
-
-    pub fn new() -> Playout {
-        Playout
-    }
-
-    pub fn run(&self, b: &Board, initial_move: &Move, rng: &mut XorShiftRng) -> PlayoutResult {
+    fn run(&self, b: &Board, initial_move: &Move, rng: &mut XorShiftRng) -> PlayoutResult {
         let mut board = b.clone();
         let mut played_moves = Vec::new();
         board.play(*initial_move);
@@ -45,14 +43,14 @@ impl Playout {
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
             let m = board.playout_move(rng);
-
-
             board.play(m);
             played_moves.push(m);
             move_count += 1;
         }
         PlayoutResult::new(played_moves, board.winner())
     }
+
+    fn moves(&self, b: &Board) -> Vec<Move>;
 
     fn max_moves(&self, size: u8) -> usize {
         size as usize * size as usize * 3

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -32,6 +32,19 @@ mod no_eyes;
 mod simple;
 mod test;
 
+pub fn factory(opt: Option<String>) -> Box<Playout> {
+    match opt {
+        Some(s) => {
+            match s.as_slice() {
+                "simple" => Box::new(SimplePlayout::new()),
+                _ => Box::new(NoEyesPlayout::new()),
+            }
+        },
+        None => Box::new(NoEyesPlayout::new())
+    }
+}
+
+
 pub trait Playout: Sync + Send {
 
     fn run(&self, b: &Board, initial_move: &Move, rng: &mut XorShiftRng) -> PlayoutResult {
@@ -55,6 +68,8 @@ pub trait Playout: Sync + Send {
     fn max_moves(&self, size: u8) -> usize {
         size as usize * size as usize * 3
     }
+
+    fn playout_type(&self) -> String;
 
 }
 

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -24,9 +24,8 @@ pub use self::simple::SimplePlayout;
 use board::Board;
 use board::Move;
 use board::Color;
-use board::Pass;
 
-use rand::{Rng, XorShiftRng};
+use rand::XorShiftRng;
 
 mod no_eyes;
 mod simple;

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -28,35 +28,47 @@ use rand::{Rng, XorShiftRng};
 
 mod test;
 
-pub struct Playout {
-    moves: Vec<Move>,
-    winner: Color,
-}
+pub struct Playout;
 
 impl Playout {
-    pub fn run(b: &Board, initial_move: &Move, rng: &mut XorShiftRng) -> Playout {
+
+    pub fn new() -> Playout {
+        Playout
+    }
+
+    pub fn run(&self, b: &Board, initial_move: &Move, rng: &mut XorShiftRng) -> PlayoutResult {
         let mut board = b.clone();
         let mut played_moves = Vec::new();
         board.play(*initial_move);
         played_moves.push(*initial_move);
-        let max_moves = Playout::max_moves(board.size());
+        let max_moves = self.max_moves(board.size());
         let mut move_count = 0;
         while !board.is_game_over() && move_count < max_moves {
             let m = board.playout_move(rng);
-            
-            
+
+
             board.play(m);
             played_moves.push(m);
             move_count += 1;
         }
-        Playout {
-            moves: played_moves,
-            winner: board.winner(),
-        }
+        PlayoutResult::new(played_moves, board.winner())
     }
 
-    pub fn max_moves(size: u8) -> usize {
+    fn max_moves(&self, size: u8) -> usize {
         size as usize * size as usize * 3
+    }
+
+}
+
+pub struct PlayoutResult {
+    moves: Vec<Move>,
+    winner: Color,
+}
+
+impl PlayoutResult {
+
+    pub fn new(moves: Vec<Move>, winner: Color) -> PlayoutResult {
+        PlayoutResult { moves: moves, winner: winner }
     }
 
     pub fn moves(&self) -> &Vec<Move> {
@@ -66,4 +78,5 @@ impl Playout {
     pub fn winner(&self) -> Color {
         self.winner
     }
+
 }

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -36,8 +36,39 @@ impl NoEyesPlayout {
 
 impl Playout for NoEyesPlayout {
 
-    fn moves(&self, b: &Board) -> Vec<Move> {
-        b.legal_moves_without_eyes()
+    fn is_playable(&self, board: &Board, m: &Move) -> bool {
+        !board.is_eye(&m.coord(), *m.color())
+    }
+
+    fn include_pass(&self) -> bool {
+        false
+    }
+
+    fn playout_type(&self) -> String {
+        format!("{:?}", self)
+    }
+
+}
+
+#[derive(Debug)]
+pub struct NoEyesWithPassPlayout;
+
+impl NoEyesWithPassPlayout {
+
+    pub fn new() -> NoEyesWithPassPlayout {
+        NoEyesWithPassPlayout
+    }
+
+}
+
+impl Playout for NoEyesWithPassPlayout {
+
+    fn is_playable(&self, board: &Board, m: &Move) -> bool {
+        !board.is_eye(&m.coord(), *m.color())
+    }
+
+    fn include_pass(&self) -> bool {
+        true
     }
 
     fn playout_type(&self) -> String {

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -23,6 +23,7 @@ use board::Board;
 use board::Move;
 use super::Playout;
 
+#[derive(Debug)]
 pub struct NoEyesPlayout;
 
 impl NoEyesPlayout {
@@ -37,6 +38,10 @@ impl Playout for NoEyesPlayout {
 
     fn moves(&self, b: &Board) -> Vec<Move> {
         b.legal_moves_without_eyes()
+    }
+
+    fn playout_type(&self) -> String {
+        format!("{:?}", self)
     }
 
 }

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -19,29 +19,24 @@
  *                                                                      *
  ************************************************************************/
 
-use playout::Playout;
-use playout::SimplePlayout;
-use ruleset::Minimal;
-use ruleset::Ruleset;
+use board::Board;
+use board::Move;
+use super::Playout;
 
-use std::sync::Arc;
+pub struct NoEyesPlayout;
 
-pub struct Config {
-    pub log: bool,
-    pub playout: Box<Playout>,
-    pub ruleset: Ruleset,
-    pub threads: usize,
+impl NoEyesPlayout {
+
+    pub fn new() -> NoEyesPlayout {
+        NoEyesPlayout
+    }
+
 }
 
-impl Config {
+impl Playout for NoEyesPlayout {
 
-    pub fn default() -> Config {
-        Config {
-            log: false,
-            playout: Box::new(SimplePlayout::new()),
-            ruleset: Minimal,
-            threads: 1,
-        }
+    fn moves(&self, b: &Board) -> Vec<Move> {
+        b.legal_moves_without_eyes()
     }
 
 }

--- a/src/playout/simple.rs
+++ b/src/playout/simple.rs
@@ -23,6 +23,7 @@ use board::Board;
 use board::Move;
 use super::Playout;
 
+#[derive(Debug)]
 pub struct SimplePlayout;
 
 impl SimplePlayout {
@@ -39,4 +40,7 @@ impl Playout for SimplePlayout {
         b.legal_moves_without_superko_check()
     }
 
+    fn playout_type(&self) -> String {
+        format!("{:?}", self)
+    }
 }

--- a/src/playout/simple.rs
+++ b/src/playout/simple.rs
@@ -36,8 +36,38 @@ impl SimplePlayout {
 
 impl Playout for SimplePlayout {
 
-    fn moves(&self, b: &Board) -> Vec<Move> {
-        b.legal_moves_without_superko_check()
+    fn is_playable(&self, _: &Board, _: &Move) -> bool {
+        true
+    }
+
+    fn include_pass(&self) -> bool {
+        false
+    }
+
+    fn playout_type(&self) -> String {
+        format!("{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub struct SimpleWithPassPlayout;
+
+impl SimpleWithPassPlayout {
+
+    pub fn new() -> SimpleWithPassPlayout {
+        SimpleWithPassPlayout
+    }
+
+}
+
+impl Playout for SimpleWithPassPlayout {
+
+    fn is_playable(&self, _: &Board, _: &Move) -> bool {
+        true
+    }
+
+    fn include_pass(&self) -> bool {
+        true
     }
 
     fn playout_type(&self) -> String {

--- a/src/playout/simple.rs
+++ b/src/playout/simple.rs
@@ -19,29 +19,24 @@
  *                                                                      *
  ************************************************************************/
 
-use playout::Playout;
-use playout::SimplePlayout;
-use ruleset::Minimal;
-use ruleset::Ruleset;
+use board::Board;
+use board::Move;
+use super::Playout;
 
-use std::sync::Arc;
+pub struct SimplePlayout;
 
-pub struct Config {
-    pub log: bool,
-    pub playout: Box<Playout>,
-    pub ruleset: Ruleset,
-    pub threads: usize,
+impl SimplePlayout {
+
+    pub fn new() -> SimplePlayout {
+        SimplePlayout
+    }
+
 }
 
-impl Config {
+impl Playout for SimplePlayout {
 
-    pub fn default() -> Config {
-        Config {
-            log: false,
-            playout: Box::new(SimplePlayout::new()),
-            ruleset: Minimal,
-            threads: 1,
-        }
+    fn moves(&self, b: &Board) -> Vec<Move> {
+        b.legal_moves_without_superko_check()
     }
 
 }

--- a/src/playout/test.rs
+++ b/src/playout/test.rs
@@ -34,16 +34,17 @@ fn should_add_the_passed_moves_as_the_first_move() {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-    
-    let playout = Playout::run(&board, &Play(Black, 1, 1), &mut rng);
-    assert_eq!(Play(Black, 1, 1), playout.moves()[0]);
+    let playout = Playout::new();
+    let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
+    assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
 
 #[test]
 fn max_moves() {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
-    assert_eq!(1083, Playout::max_moves(19));
+    let playout = Playout::new();
+    assert_eq!(1083, playout.max_moves(19));
 }
 
 #[bench]
@@ -51,8 +52,8 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-
-    b.iter(|| Playout::run(&board, &Play(Black, 1, 1), &mut rng))
+    let playout = Playout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }
 
 #[bench]
@@ -60,8 +61,8 @@ fn bench_13x13_playout_speed(b: &mut Bencher) {
     let game = Game::new(13, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-
-    b.iter(|| Playout::run(&board, &Play(Black, 1, 1), &mut rng))
+    let playout = Playout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }
 
 #[bench]
@@ -69,6 +70,6 @@ fn bench_19x19_playout_speed(b: &mut Bencher) {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-
-    b.iter(|| Playout::run(&board, &Play(Black, 1, 1), &mut rng))
+    let playout = Playout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -21,8 +21,6 @@
 
 #![cfg(test)]
 
-use super::NoEyesPlayout;
-
 mod no_eyes;
 mod simple;
 

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -21,5 +21,25 @@
 
 #![cfg(test)]
 
+use super::NoEyesPlayout;
+
 mod no_eyes;
 mod simple;
+
+#[test]
+fn factory_returns_no_eyes_by_default() {
+    let playout = super::factory(None);
+    assert_eq!("NoEyesPlayout", playout.playout_type());
+}
+
+#[test]
+fn factory_returns_simple_when_given_simple() {
+    let playout = super::factory(Some(String::from_str("simple")));
+    assert_eq!("SimplePlayout", playout.playout_type());
+}
+
+#[test]
+fn factroy_returns_no_eyes_when_given_any_string() {
+    let playout = super::factory(Some(String::from_str("foo")));
+    assert_eq!("NoEyesPlayout", playout.playout_type());
+}

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -31,13 +31,25 @@ fn factory_returns_no_eyes_by_default() {
 }
 
 #[test]
-fn factory_returns_simple_when_given_simple() {
+fn factory_returns_simple() {
     let playout = super::factory(Some(String::from_str("simple")));
     assert_eq!("SimplePlayout", playout.playout_type());
+}
+
+#[test]
+fn factory_returns_simple_with_pass() {
+    let playout = super::factory(Some(String::from_str("simple-with-pass")));
+    assert_eq!("SimpleWithPassPlayout", playout.playout_type());
 }
 
 #[test]
 fn factroy_returns_no_eyes_when_given_any_string() {
     let playout = super::factory(Some(String::from_str("foo")));
     assert_eq!("NoEyesPlayout", playout.playout_type());
+}
+
+#[test]
+fn factory_returns_no_eyes_with_pass() {
+    let playout = super::factory(Some(String::from_str("no-eyes-with-pass")));
+    assert_eq!("NoEyesWithPassPlayout", playout.playout_type());
 }

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Thomas Poinsot, Urban Hafner                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -19,29 +19,7 @@
  *                                                                      *
  ************************************************************************/
 
-use playout::Playout;
-use playout::SimplePlayout;
-use ruleset::Minimal;
-use ruleset::Ruleset;
+#![cfg(test)]
 
-use std::sync::Arc;
-
-pub struct Config {
-    pub log: bool,
-    pub playout: Box<Playout>,
-    pub ruleset: Ruleset,
-    pub threads: usize,
-}
-
-impl Config {
-
-    pub fn default() -> Config {
-        Config {
-            log: false,
-            playout: Box::new(SimplePlayout::new()),
-            ruleset: Minimal,
-            threads: 1,
-        }
-    }
-
-}
+mod no_eyes;
+mod simple;

--- a/src/playout/test/no_eyes.rs
+++ b/src/playout/test/no_eyes.rs
@@ -25,18 +25,17 @@ use board::Black;
 use board::Board;
 use board::Play;
 use playout::NoEyesPlayout;
+use playout::NoEyesWithPassPlayout;
 use playout::Playout;
 use ruleset::KgsChinese;
 
-use rand::weak_rng;
 use test::Bencher;
 
 #[test]
 fn should_add_the_passed_moves_as_the_first_move() {
     let board = Board::new(9, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
-    let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
+    let result = playout.run(&board, &Play(Black, 1, 1));
     assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
 
@@ -47,25 +46,43 @@ fn max_moves() {
 }
 
 #[bench]
-fn bench_9x9_playout_speed(b: &mut Bencher) {
+fn no_eyes_09x09(b: &mut Bencher) {
     let board = Board::new(9, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
-fn bench_13x13_playout_speed(b: &mut Bencher) {
+fn no_eyes_13x13(b: &mut Bencher) {
     let board = Board::new(13, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
 }
 
 #[bench]
-fn bench_19x19_playout_speed(b: &mut Bencher) {
+fn no_eyes_19x19(b: &mut Bencher) {
     let board = Board::new(19, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+}
+
+#[bench]
+fn with_pass_09x09(b: &mut Bencher) {
+    let board = Board::new(9, 6.5, KgsChinese);
+    let playout = NoEyesWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+}
+
+#[bench]
+fn with_pass_13x13(b: &mut Bencher) {
+    let board = Board::new(13, 6.5, KgsChinese);
+    let playout = NoEyesWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+}
+
+#[bench]
+fn with_pass_19x19(b: &mut Bencher) {
+    let board = Board::new(19, 6.5, KgsChinese);
+    let playout = NoEyesWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
 }

--- a/src/playout/test/no_eyes.rs
+++ b/src/playout/test/no_eyes.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Thomas Poinsot, Igor Polyakov                         *
+ * Copyright 2015 Thomas Poinsot, Igor Polyakov, Urban Hafner           *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -24,6 +24,7 @@
 use board::Black;
 use board::Play;
 use game::Game;
+use playout::NoEyesPlayout;
 use playout::Playout;
 use rand::{Rng, weak_rng};
 use ruleset::KgsChinese;
@@ -34,7 +35,7 @@ fn should_add_the_passed_moves_as_the_first_move() {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-    let playout = Playout::new();
+    let playout = NoEyesPlayout::new();
     let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
     assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
@@ -43,7 +44,7 @@ fn should_add_the_passed_moves_as_the_first_move() {
 fn max_moves() {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
-    let playout = Playout::new();
+    let playout = NoEyesPlayout::new();
     assert_eq!(1083, playout.max_moves(19));
 }
 
@@ -52,7 +53,7 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
     let game = Game::new(9, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-    let playout = Playout::new();
+    let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }
 
@@ -61,7 +62,7 @@ fn bench_13x13_playout_speed(b: &mut Bencher) {
     let game = Game::new(13, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-    let playout = Playout::new();
+    let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }
 
@@ -70,6 +71,6 @@ fn bench_19x19_playout_speed(b: &mut Bencher) {
     let game = Game::new(19, 6.5, KgsChinese);
     let board = game.board();
     let mut rng = weak_rng();
-    let playout = Playout::new();
+    let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
 }

--- a/src/playout/test/no_eyes.rs
+++ b/src/playout/test/no_eyes.rs
@@ -22,18 +22,18 @@
 #![cfg(test)]
 
 use board::Black;
+use board::Board;
 use board::Play;
-use game::Game;
 use playout::NoEyesPlayout;
 use playout::Playout;
-use rand::{Rng, weak_rng};
 use ruleset::KgsChinese;
+
+use rand::weak_rng;
 use test::Bencher;
 
 #[test]
 fn should_add_the_passed_moves_as_the_first_move() {
-    let game = Game::new(9, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(9, 6.5, KgsChinese);
     let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
     let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
@@ -42,16 +42,13 @@ fn should_add_the_passed_moves_as_the_first_move() {
 
 #[test]
 fn max_moves() {
-    let game = Game::new(19, 6.5, KgsChinese);
-    let board = game.board();
     let playout = NoEyesPlayout::new();
     assert_eq!(1083, playout.max_moves(19));
 }
 
 #[bench]
 fn bench_9x9_playout_speed(b: &mut Bencher) {
-    let game = Game::new(9, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(9, 6.5, KgsChinese);
     let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
@@ -59,8 +56,7 @@ fn bench_9x9_playout_speed(b: &mut Bencher) {
 
 #[bench]
 fn bench_13x13_playout_speed(b: &mut Bencher) {
-    let game = Game::new(13, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(13, 6.5, KgsChinese);
     let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))
@@ -68,8 +64,7 @@ fn bench_13x13_playout_speed(b: &mut Bencher) {
 
 #[bench]
 fn bench_19x19_playout_speed(b: &mut Bencher) {
-    let game = Game::new(19, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(19, 6.5, KgsChinese);
     let mut rng = weak_rng();
     let playout = NoEyesPlayout::new();
     b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng))

--- a/src/playout/test/simple.rs
+++ b/src/playout/test/simple.rs
@@ -22,51 +22,50 @@
 #![cfg(test)]
 
 use board::Black;
+use board::Board;
 use board::Play;
-use game::Game;
 use playout::Playout;
 use playout::SimplePlayout;
 use ruleset::KgsChinese;
 
+use rand::weak_rng;
 use test::Bencher;
 
 #[test]
 fn should_add_the_passed_moves_as_the_first_move() {
-    let game = Game::new(9, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(9, 6.5, KgsChinese);
+    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    let result = playout.run(&board, &Play(Black, 1, 1));
+    let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
     assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
 
 #[test]
 fn max_moves() {
-    let game = Game::new(19, 6.5, KgsChinese);
-    let board = game.board();
     let playout = SimplePlayout::new();
     assert_eq!(1083, playout.max_moves(19));
 }
 
 #[bench]
 fn bench_9x9_playout_speed(b: &mut Bencher) {
-    let game = Game::new(9, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(9, 6.5, KgsChinese);
+    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
 }
 
 #[bench]
 fn bench_13x13_playout_speed(b: &mut Bencher) {
-    let game = Game::new(13, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(13, 6.5, KgsChinese);
+    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
 }
 
 #[bench]
 fn bench_19x19_playout_speed(b: &mut Bencher) {
-    let game = Game::new(19, 6.5, KgsChinese);
-    let board = game.board();
+    let board = Board::new(19, 6.5, KgsChinese);
+    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
 }

--- a/src/playout/test/simple.rs
+++ b/src/playout/test/simple.rs
@@ -1,6 +1,6 @@
 /************************************************************************
  *                                                                      *
- * Copyright 2015 Urban Hafner                                          *
+ * Copyright 2015 Thomas Poinsot, Urban Hafner                          *
  *                                                                      *
  * This file is part of Iomrascálaí.                                    *
  *                                                                      *
@@ -19,29 +19,54 @@
  *                                                                      *
  ************************************************************************/
 
+#![cfg(test)]
+
+use board::Black;
+use board::Play;
+use game::Game;
 use playout::Playout;
 use playout::SimplePlayout;
-use ruleset::Minimal;
-use ruleset::Ruleset;
+use ruleset::KgsChinese;
 
-use std::sync::Arc;
+use test::Bencher;
 
-pub struct Config {
-    pub log: bool,
-    pub playout: Box<Playout>,
-    pub ruleset: Ruleset,
-    pub threads: usize,
+#[test]
+fn should_add_the_passed_moves_as_the_first_move() {
+    let game = Game::new(9, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = SimplePlayout::new();
+    let result = playout.run(&board, &Play(Black, 1, 1));
+    assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
 
-impl Config {
+#[test]
+fn max_moves() {
+    let game = Game::new(19, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = SimplePlayout::new();
+    assert_eq!(1083, playout.max_moves(19));
+}
 
-    pub fn default() -> Config {
-        Config {
-            log: false,
-            playout: Box::new(SimplePlayout::new()),
-            ruleset: Minimal,
-            threads: 1,
-        }
-    }
+#[bench]
+fn bench_9x9_playout_speed(b: &mut Bencher) {
+    let game = Game::new(9, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = SimplePlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+}
 
+#[bench]
+fn bench_13x13_playout_speed(b: &mut Bencher) {
+    let game = Game::new(13, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = SimplePlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
+}
+
+#[bench]
+fn bench_19x19_playout_speed(b: &mut Bencher) {
+    let game = Game::new(19, 6.5, KgsChinese);
+    let board = game.board();
+    let playout = SimplePlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)))
 }

--- a/src/playout/test/simple.rs
+++ b/src/playout/test/simple.rs
@@ -26,17 +26,16 @@ use board::Board;
 use board::Play;
 use playout::Playout;
 use playout::SimplePlayout;
+use playout::SimpleWithPassPlayout;
 use ruleset::KgsChinese;
 
-use rand::weak_rng;
 use test::Bencher;
 
 #[test]
 fn should_add_the_passed_moves_as_the_first_move() {
     let board = Board::new(9, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    let result = playout.run(&board, &Play(Black, 1, 1), &mut rng);
+    let result = playout.run(&board, &Play(Black, 1, 1));
     assert_eq!(Play(Black, 1, 1), result.moves()[0]);
 }
 
@@ -47,25 +46,43 @@ fn max_moves() {
 }
 
 #[bench]
-fn bench_9x9_playout_speed(b: &mut Bencher) {
+fn simple_09x09(b: &mut Bencher) {
     let board = Board::new(9, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
 }
 
 #[bench]
-fn bench_13x13_playout_speed(b: &mut Bencher) {
+fn simple_13x13(b: &mut Bencher) {
     let board = Board::new(13, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
 }
 
 #[bench]
-fn bench_19x19_playout_speed(b: &mut Bencher) {
+fn simple_19x19(b: &mut Bencher) {
     let board = Board::new(19, 6.5, KgsChinese);
-    let mut rng = weak_rng();
     let playout = SimplePlayout::new();
-    b.iter(|| playout.run(&board, &Play(Black, 1, 1), &mut rng));
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
+}
+
+#[bench]
+fn with_pass_09x09(b: &mut Bencher) {
+    let board = Board::new(9, 6.5, KgsChinese);
+    let playout = SimpleWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
+}
+
+#[bench]
+fn with_pass_13x13(b: &mut Bencher) {
+    let board = Board::new(13, 6.5, KgsChinese);
+    let playout = SimpleWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
+}
+
+#[bench]
+fn with_pass_19x19(b: &mut Bencher) {
+    let board = Board::new(19, 6.5, KgsChinese);
+    let playout = SimpleWithPassPlayout::new();
+    b.iter(|| playout.run(&board, &Play(Black, 1, 1)));
 }


### PR DESCRIPTION
This adds the `-p` or `--playout` command line switch to select which kind of playout to use. There are the following four types:

* `NoEyesPlayout`: Selects from legal moves that aren't eyes. Passes only when there are no other possible moves.
* `NoEyesWithPassPlayout`: Selects from legal moves that aren't eyes, but also adds the pass move to the selection (resulting in shorter playouts)
* `SimplePlayout`: Selects from legal moves. Passes only when there are no other possible moves.
* `SimpleWithPassPlayout`: Selects from legal moves, but also adds the pass move to the selection (resulting in shorter playouts).

It also moves the move selection for a playout back into the `Playout`. Tests for the `Playout` stuff will follow, but I wanted to get the code into `master` so that @iopq can continue working on his stuff.

Thanks to @skade for the help figuring out how to pass a `Box` into multiple threads.

BTW, the decrease in code coverage is due to the fact that more files are now analysed by `kcov`. In the current master `kcov` only picks up 37 files, now it analyzes 47 of 50.