### PR TITLE
compiling with lto for releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ regex_macros    = "*"
 rustc-serialize = "*"
 strenum         = "*"
 time            = "*"
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,3 @@ opt-level = 3
 debug = false
 rpath = false
 lto = true
-debug-assertions = false


### PR DESCRIPTION
Build releases with link time optimization

a slight improvement in performance and increase in compile time only if compiled with cargo build --release
other compile times not affected