### PR TITLE
Adds the engine name to the GTP name command output

### DIFF
--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -33,7 +33,7 @@ pub struct Driver;
 
 impl Driver {
     pub fn new(config: Arc<Config>, engine: Box<Engine>) {
-        let engine_name = "Iomrascalai";
+        let engine_name = format!("Iomrascalai ({})", engine.engine_type());
         let engine_version = version::version();
         let protocol_version = "2";
 


### PR DESCRIPTION
This is what Gogui uses to display in the title of the board. Adding the engine type here is a good reminder as to which version is playing. Especially during self play.