### PR TITLE
Expand after 10 plays

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub playout: Box<Playout>,
     pub ruleset: Ruleset,
     pub threads: usize,
+    pub uct_expand_after: usize,
 }
 
 impl Config {
@@ -39,6 +40,7 @@ impl Config {
             playout: Box::new(NoEyesPlayout::new()),
             ruleset: Minimal,
             threads: 1,
+            uct_expand_after: 10,
         }
     }
 

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -75,7 +75,7 @@ impl Engine for UctEngine {
                 res = receive_result_from_threads.recv() => {
                     let ((path, winner), send_to_thread) = res.unwrap();
                     root.record_on_path(&path, winner);
-                    let data = root.find_leaf_and_expand(game);
+                    let data = root.find_leaf_and_expand(game, self.config.uct_expand_after);
                     send_to_thread.send(data);
                 }
                 )

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -64,18 +64,18 @@ impl Node {
         root
     }
 
-    pub fn find_leaf_and_expand(&mut self, game: &Game) -> (Vec<usize>, Vec<Move>, bool) {
+    pub fn find_leaf_and_expand(&mut self, game: &Game, expand_after: usize) -> (Vec<usize>, Vec<Move>, bool) {
         let (path, moves, leaf) = self.find_leaf_and_mark(vec!(), vec!());
         let mut board = game.board();
         for &m in moves.iter() {
             board.play(m);
         }
-        let expanded = leaf.expand(&board);
-        if !expanded {
+        let not_terminal = leaf.expand(&board, expand_after);
+        if !not_terminal {
             let is_win = board.winner() == leaf.color();
             leaf.mark_as_terminal(is_win);
         }
-        (path, moves, expanded)
+        (path, moves, not_terminal)
     }
 
     pub fn find_leaf_and_mark(&mut self, mut path: Vec<usize>, mut moves: Vec<Move>) -> (Vec<usize>, Vec<Move>, &mut Node) {
@@ -99,16 +99,15 @@ impl Node {
         }
  }
 
-    pub fn expand(&mut self, board: &Board) -> bool {
-        let expanded = !board.is_game_over();
-        if expanded {
+    pub fn expand(&mut self, board: &Board, expand_after: usize) -> bool {
+        let not_terminal = !board.is_game_over();
+        if not_terminal && self.plays >= expand_after {
             self.children = board.legal_moves_without_eyes()
                 .iter()
                 .map(|&m| Node::new(m))
                 .collect();
         }
-
-        expanded
+        not_terminal
     }
 
     pub fn has_no_children(&self) -> bool {

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -49,8 +49,25 @@ fn expand_doesnt_add_children_to_terminal_nodes() {
     game = game.play(Pass(Black)).unwrap();
     game = game.play(Pass(White)).unwrap();
     let mut node = Node::new(Pass(Black));
-    node.expand(&game.board());
+    node.expand(&game.board(), 1);
     assert_eq!(0, node.children.len());
+}
+
+#[test]
+fn expand_doesnt_add_children_if_threshold_not_met() {
+    let game = Game::new(2, 0.5, KgsChinese);
+    let mut node = Node::new(Pass(Black));
+    node.expand(&game.board(), 2);
+    assert_eq!(0, node.children.len());
+}
+
+#[test]
+fn expand_adds_children_if_threshold_is_met() {
+    let game = Game::new(2, 0.5, KgsChinese);
+    let mut node = Node::new(Pass(Black));
+    node.plays = 2;
+    node.expand(&game.board(), 2);
+    assert_eq!(4, node.children.len());
 }
 
 #[test]
@@ -60,7 +77,7 @@ fn unvisited_children_are_explored_first() {
     let config = Arc::new(Config::default());
     let mut rng = weak_rng();
     for _ in 0..4 {
-        root.find_leaf_and_expand(&game);
+        root.find_leaf_and_expand(&game, 1);
     }
     assert_eq!(4, root.children.len());
     assert!(root.children.iter().all(|n| n.plays == 1));
@@ -73,7 +90,7 @@ fn find_leaf_and_expand_expands_the_leaves() {
     let config = Arc::new(Config::default());
     let mut rng = weak_rng();
     for _ in 0..4 {
-        root.find_leaf_and_expand(&game);
+        root.find_leaf_and_expand(&game, 1);
     }
     assert_eq!(4, root.children.len());
     assert!(root.children.iter().all(|n| n.children.len() == 3));
@@ -85,7 +102,7 @@ fn run_playout_sets_play_on_the_root() {
     let mut root = Node::root(&game, Black);
     let config = Arc::new(Config::default());
     let mut rng = weak_rng();
-    root.find_leaf_and_expand(&game);
+    root.find_leaf_and_expand(&game, 1);
     assert_eq!(2, root.plays);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,12 +108,12 @@ pub fn main() {
         Some(r) => Ruleset::from_string(r),
         None    => KgsChinese
     };
-    let config = Arc::new(Config {
-        log: log,
-        playout: playout::factory(matches.opt_str("p")),
-        ruleset: ruleset,
-        threads: threads,
-    });
+    let mut config = Config::default();
+    config.log = log;
+    config.playout = playout::factory(matches.opt_str("p"));
+    config.ruleset = ruleset;
+    config.threads = threads;
+    let config = Arc::new(config);
     let engine = engine::factory(matches.opt_str("e"), config.clone());
     Driver::new(config.clone(), engine);
 }


### PR DESCRIPTION
As @iopq pointed out expanding the leaves of the UCT tree after 10 playouts instead of 1 might lead to better play. Here's the code for it.

To make this configurable I've put the actual number of playouts after which the leaves will be expanded into the `Config` struct.