### PR TITLE
speeding up no self atari playout type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strenum 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -57,6 +58,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "smallvec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ regex           = "*"
 regex_macros    = "*"
 strenum         = "*"
 time            = "*"
+smallvec        = "*"
 
 [profile.release]
 opt-level = 3

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
+use smallvec::SmallVec4;
 
 mod chain;
 mod coord;
@@ -639,34 +640,20 @@ impl Board {
     }
     
     pub fn new_chain_length_less_than(&self, m: Move, limit: usize) -> bool {
-        let mut set: HashSet<&Coord> = HashSet::new();
+        let mut chain_ids = SmallVec4::new();
+        let mut length = 0;
         
         for &c in self.neighbours(m.coord()).iter() {
             if self.color(&c) == *m.color() {
-                for coord in self.get_chain(c).unwrap().coords().iter() {
-                    set.insert(coord);
-                    if set.len() + 1 > limit {
-                        return false;
-                    }
+                let chain = self.get_chain(c).unwrap();
+                
+                if !chain_ids.contains(&chain.id()) {
+                    length += chain.coords().len();
+                    chain_ids.push(chain.id());
                 }
-            }
-        }
-        
-        true
-    }
-    
-    pub fn new_chain_length_less_than_three(&self, m: Move) -> bool {
-        let mut one_neighbour_found = false;
-        for &c in self.neighbours(m.coord()).iter() {
-            if self.color(&c) == *m.color() {
-                if one_neighbour_found {
+   
+                if length + 1 > limit {
                     return false;
-                } else {
-                    if self.get_chain(c).unwrap().coords().len() > 1 {
-                        return false;
-                    } else {
-                        one_neighbour_found = true;
-                    }
                 }
             }
         }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -597,6 +597,47 @@ impl Board {
         false
     }
     
+    pub fn new_chain_liberties_greater_than_zero(&self, m: Move) -> bool {
+        for &c in self.neighbours(m.coord()).iter() {
+            if self.color(&c) == *m.color() {
+                for &liberty in self.get_chain(c).unwrap().liberties() {
+                    if liberty != m.coord() {
+                        return true;
+                    }
+                }
+            } else if self.color(&c) == Empty {
+                return true;
+            }
+        }
+        
+        false
+    }
+    
+    pub fn new_chain_liberties_greater_than_one(&self, m: Move) -> bool {
+        let mut first_liberty: Option<Coord> = None;
+        for &c in self.neighbours(m.coord()).iter() {
+            if self.color(&c) == *m.color() {
+                for &liberty in self.get_chain(c).unwrap().liberties() {
+                    if liberty != m.coord() && first_liberty.is_none() {
+                        first_liberty = Some(liberty);
+                    } else if liberty != m.coord() && first_liberty.is_some() {
+                        if Some(liberty) != first_liberty {
+                            return true;
+                        }
+                    }
+                }
+            } else if self.color(&c) == Empty {
+                if first_liberty.is_none() {
+                    first_liberty = Some(c);
+                } else if Some(c) != first_liberty {
+                    return true;
+                }
+            }
+        }
+        
+        false
+    }
+    
     pub fn new_chain_length_less_than(&self, m: Move, limit: usize) -> bool {
         let mut set: HashSet<&Coord> = HashSet::new();
         
@@ -606,6 +647,25 @@ impl Board {
                     set.insert(coord);
                     if set.len() + 1 > limit {
                         return false;
+                    }
+                }
+            }
+        }
+        
+        true
+    }
+    
+    pub fn new_chain_length_less_than_three(&self, m: Move) -> bool {
+        let mut one_neighbour_found = false;
+        for &c in self.neighbours(m.coord()).iter() {
+            if self.color(&c) == *m.color() {
+                if one_neighbour_found {
+                    return false;
+                } else {
+                    if self.get_chain(c).unwrap().coords().len() > 1 {
+                        return false;
+                    } else {
+                        one_neighbour_found = true;
                     }
                 }
             }

--- a/src/board/test/hypotheticals.rs
+++ b/src/board/test/hypotheticals.rs
@@ -63,7 +63,10 @@ fn removes_one_stone() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/hypothetical-plays.sgf")).unwrap();
     let game   = parser.game().unwrap();
     let board  = game.board();
-    assert_eq!(1, board.removes_enemy_neighbouring_stones(Play(Black, 4, 19)));
+    let play   = Play(Black, 4, 19);
+    assert_eq!(1, board.removes_enemy_neighbouring_stones(play));
+    assert!(!board.new_chain_liberties_greater_than_zero(play)); //doesn't check for removing stones
+    assert!(!board.new_chain_liberties_greater_than_one(play));
 }
 
 #[test]
@@ -71,7 +74,10 @@ fn removes_two_stones() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/hypothetical-plays.sgf")).unwrap();
     let game   = parser.game().unwrap();
     let board  = game.board();
-    assert_eq!(2, board.removes_enemy_neighbouring_stones(Play(Black, 4, 15)));
+    let play   = Play(Black, 4, 15);
+    assert_eq!(2, board.removes_enemy_neighbouring_stones(play));
+    assert!(board.new_chain_liberties_greater_than_zero(play));
+    assert!(board.new_chain_liberties_greater_than_one(play));
 }
 
 #[test]
@@ -79,7 +85,10 @@ fn removes_three_stones() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/hypothetical-plays.sgf")).unwrap();
     let game   = parser.game().unwrap();
     let board  = game.board();
-    assert_eq!(3, board.removes_enemy_neighbouring_stones(Play(Black, 4, 10)));
+    let play   = Play(Black, 4, 10);
+    assert_eq!(3, board.removes_enemy_neighbouring_stones(play));
+    assert!(board.new_chain_liberties_greater_than_zero(play));
+    assert!(!board.new_chain_liberties_greater_than_one(play)); //doesn't check for removing stones
 }
 
 #[test]
@@ -87,7 +96,10 @@ fn removes_four_stones() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/hypothetical-plays.sgf")).unwrap();
     let game   = parser.game().unwrap();
     let board  = game.board();
-    assert_eq!(4, board.removes_enemy_neighbouring_stones(Play(Black, 4, 4)));
+    let play   = Play(Black, 4, 4);
+    assert_eq!(4, board.removes_enemy_neighbouring_stones(play));
+    assert!(!board.new_chain_liberties_greater_than_zero(play)); //doesn't check for removing stones
+    assert!(!board.new_chain_liberties_greater_than_one(play));
 }
 
 #[test]
@@ -113,6 +125,7 @@ fn two_stones_have_six_liberties() {
     let board  = game.board();
     
     let play = Play(Black, 10, 12);
+    assert!(board.new_chain_length_less_than_three(play));
     assert!(board.new_chain_length_less_than(play, 3));
     assert!(board.new_chain_liberties_greater_than(play, 5));
 }

--- a/src/board/test/hypotheticals.rs
+++ b/src/board/test/hypotheticals.rs
@@ -125,7 +125,6 @@ fn two_stones_have_six_liberties() {
     let board  = game.board();
     
     let play = Play(Black, 10, 12);
-    assert!(board.new_chain_length_less_than_three(play));
     assert!(board.new_chain_length_less_than(play, 3));
     assert!(board.new_chain_liberties_greater_than(play, 5));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ extern crate getopts;
 extern crate rand;
 extern crate regex;
 #[no_link] extern crate regex_macros;
+extern crate smallvec;
 extern crate test;
 extern crate time;
 #[macro_use(strenum)] extern crate strenum;

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -75,14 +75,11 @@ pub trait Playout: Sync + Send {
             loop {
                 let first = playable_move.unwrap();
                 let r = first + rng.gen::<usize>() % (vacant.len() - first);
-                if r == vacant.len() {
-                    return Pass(color);
-                } else {
-                    let c = vacant[r];
-                    let m = Play(color, c.col, c.row);
-                    if board.is_legal(m).is_ok() && self.is_playable(board, &m) {
-                        return m;
-                    }
+                
+                let c = vacant[r];
+                let m = Play(color, c.col, c.row);
+                if board.is_legal(m).is_ok() && self.is_playable(board, &m) {
+                    return m;
                 }
             }
         } else {

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -37,7 +37,7 @@ impl Playout for NoEyesPlayout {
     }
 }
 
-//strings of 7 or more don't play self-atari in this playout
+//strings of 3 or more don't play self-atari in this playout because it makes an eye for the opponent
 #[derive(Debug)]
 pub struct NoSelfAtariPlayout;
 
@@ -53,11 +53,11 @@ impl Playout for NoSelfAtariPlayout {
                 
                 empty + removed_enemies > 1 ||
                 {
-                (removed_enemies > 0 && board.new_chain_liberties_greater_than(*m, 0)) ||
-                board.new_chain_liberties_greater_than(*m, 1)
+                (removed_enemies > 0 && board.new_chain_liberties_greater_than_zero(*m)) ||
+                board.new_chain_liberties_greater_than_one(*m)
                 }
             }
-            || board.new_chain_length_less_than(*m, 3) //you can self-atari one or two stones in playouts
+            || board.new_chain_length_less_than_three(*m) //you can self-atari one or two stones in playouts
         }
     }
     

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -37,7 +37,7 @@ impl Playout for NoEyesPlayout {
     }
 }
 
-//strings of 3 or more don't play self-atari in this playout because it makes an eye for the opponent
+//don't self atari strings that will make an eye after dying, which is strings of 7+
 #[derive(Debug)]
 pub struct NoSelfAtariPlayout;
 
@@ -57,7 +57,7 @@ impl Playout for NoSelfAtariPlayout {
                 board.new_chain_liberties_greater_than_one(*m)
                 }
             }
-            || board.new_chain_length_less_than_three(*m) //you can self-atari one or two stones in playouts
+            || board.new_chain_length_less_than(*m, 7)
         }
     }
     


### PR DESCRIPTION
Since we only use subsets of the functionality, we don't need to allocate in those cases. Then the overhead becomes negligible.

I'm leaving in the other functions because they might be useful for a semeai solver. In fact, I'm probably going to write a general 2 liberty ladder/edge solver next.