### PR TITLE
Move the various tuneable variables into the Config struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,16 +19,32 @@
  *                                                                      *
  ************************************************************************/
 
-use playout::Playout;
 use ruleset::Minimal;
 use ruleset::Ruleset;
 
+#[derive(Debug)]
+pub struct UctConfig {
+    pub expand_after: usize,
+}
+
+#[derive(Debug)]
+pub struct TimerConfig {
+    pub c: f32,
+}
+
+#[derive(Debug)]
+pub struct PlayoutConfig {
+    pub no_self_atari_cutoff: usize,
+}
+
+#[derive(Debug)]
 pub struct Config {
     pub log: bool,
-    pub playout: Box<Playout>,
+    pub playout: PlayoutConfig,
     pub ruleset: Ruleset,
     pub threads: usize,
-    pub uct_expand_after: usize,
+    pub timer: TimerConfig,
+    pub uct: UctConfig,
 }
 
 impl Config {
@@ -36,10 +52,17 @@ impl Config {
     pub fn default() -> Config {
         Config {
             log: false,
-            playout: ::playout::factory(Some(String::from_str("default"))),
+            playout: PlayoutConfig {
+                no_self_atari_cutoff: 7,
+            },
             ruleset: Minimal,
             threads: 1,
-            uct_expand_after: 1,
+            timer: TimerConfig {
+                c: 0.5
+            },
+            uct: UctConfig {
+                expand_after: 1,
+            },
         }
     }
 

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -38,6 +38,10 @@ use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
 use time::PreciseTime;
 
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
+
 pub struct EarlyReturnEngine;
 
 impl EarlyReturnEngine {
@@ -60,7 +64,7 @@ impl Engine for EarlyReturnEngine {
 fn the_engine_can_use_less_time_than_allocated() {
     let game = Game::new(19, 6.5, Minimal);
     let color = game.next_player();
-    let timer = Timer::new();
+    let timer = Timer::new(config());
     let budget = timer.budget(&game);
     let engine = Box::new(EarlyReturnEngine::new());
     let controller = EngineController::new(Arc::new(Config::default()), engine);
@@ -98,7 +102,7 @@ impl Engine for WaitingEngine {
 fn the_controller_asks_the_engine_for_a_move_when_the_time_is_up() {
     let game = Game::new(19, 6.5, Minimal);
     let color = game.next_player();
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(1, 0, 0);
     let budget = timer.budget(&game);
     let engine = Box::new(WaitingEngine::new());

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -24,6 +24,7 @@ use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
+use playout::Playout;
 use playout::PlayoutResult;
 use super::Engine;
 use super::McEngine;
@@ -34,13 +35,14 @@ use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct AmafMcEngine {
-    config: Arc<Config>
+    config: Arc<Config>,
+    playout: Arc<Box<Playout>>,
 }
 
 impl AmafMcEngine {
 
-    pub fn new(config: Arc<Config>) -> AmafMcEngine {
-        AmafMcEngine { config: config }
+    pub fn new(config: Arc<Config>, playout: Box<Playout>) -> AmafMcEngine {
+        AmafMcEngine { config: config, playout: Arc::new(playout) }
     }
 
 }
@@ -48,7 +50,7 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<AmafMcEngine>(self.config.clone(), color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(self.config.clone(), self.playout.clone(), color, game, sender, receiver);
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -24,6 +24,7 @@ use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
+use playout::Playout;
 use playout::PlayoutResult;
 use super::Engine;
 use super::McEngine;
@@ -34,13 +35,14 @@ use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct SimpleMcEngine {
-    config: Arc<Config>
+    config: Arc<Config>,
+    playout: Arc<Box<Playout>>,
 }
 
 impl SimpleMcEngine {
 
-    pub fn new(config: Arc<Config>) -> SimpleMcEngine {
-        SimpleMcEngine { config: config }
+    pub fn new(config: Arc<Config>, playout: Box<Playout>) -> SimpleMcEngine {
+        SimpleMcEngine { config: config, playout: Arc::new(playout) }
     }
 
 }
@@ -48,7 +50,7 @@ impl SimpleMcEngine {
 impl Engine for SimpleMcEngine {
 
     fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(self.config.clone(), color, game, sender, receiver);
+        super::gen_move::<SimpleMcEngine>(self.config.clone(), self.playout.clone(), color, game, sender, receiver);
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -29,6 +29,7 @@ use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
+use playout::Playout;
 
 use std::ascii::OwnedAsciiExt;
 use std::sync::Arc;
@@ -42,18 +43,18 @@ mod random;
 mod test;
 mod uct;
 
-pub fn factory(opt: Option<String>, config: Arc<Config>) -> Box<Engine> {
+pub fn factory(opt: Option<String>, config: Arc<Config>, playout: Box<Playout>) -> Box<Engine> {
     let engine_arg = opt.map(|s| s.into_ascii_lowercase());
     match engine_arg {
         Some(s) => {
             match s.as_ref() {
                 "random" => Box::new(RandomEngine::new()),
-                "mc"     => Box::new(SimpleMcEngine::new(config.clone())),
-                "amaf"   => Box::new(AmafMcEngine::new(config.clone())),
-                _        => Box::new(UctEngine::new(config.clone())),
+                "mc"     => Box::new(SimpleMcEngine::new(config.clone(), playout)),
+                "amaf"   => Box::new(AmafMcEngine::new(config.clone(), playout)),
+                _        => Box::new(UctEngine::new(config.clone(), playout)),
             }
         },
-        None => Box::new(UctEngine::new(config.clone()))
+        None => Box::new(UctEngine::new(config.clone(), playout))
     }
 }
 

--- a/src/engine/test.rs
+++ b/src/engine/test.rs
@@ -22,35 +22,45 @@
 #![cfg(test)]
 
 use config::Config;
+use playout::Playout;
+use playout;
 
 use std::sync::Arc;
 
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
+
+fn playout() -> Box<Playout> {
+    playout::factory(None, config())
+}
+
 #[test]
 fn factory_returns_uct_by_default() {
-    let engine = super::factory(None, Arc::new(Config::default()));
+    let engine = super::factory(None, config(), playout());
     assert_eq!("uct", engine.engine_type());
 }
 
 #[test]
 fn factory_returns_random_engine_when_give_random() {
-    let engine = super::factory(Some(String::from_str("random")), Arc::new(Config::default()));
+    let engine = super::factory(Some(String::from_str("random")), config(), playout());
     assert_eq!("random", engine.engine_type());
 }
 
 #[test]
 fn factory_returns_simple_mc_when_given_mc() {
-    let engine = super::factory(Some(String::from_str("mc")), Arc::new(Config::default()));
+    let engine = super::factory(Some(String::from_str("mc")), config(), playout());
     assert_eq!("simple-mc", engine.engine_type());
 }
 
 #[test]
 fn factory_returns_amaf_when_given_amaf() {
-    let engine = super::factory(Some(String::from_str("amaf")), Arc::new(Config::default()));
+    let engine = super::factory(Some(String::from_str("amaf")), config(), playout());
     assert_eq!("amaf", engine.engine_type());
 }
 
 #[test]
 fn factory_returns_uct_for_any_other_string() {
-    let engine = super::factory(Some(String::from_str("foo")), Arc::new(Config::default()));
+    let engine = super::factory(Some(String::from_str("foo")), config(), playout());
     assert_eq!("uct", engine.engine_type());
 }

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -123,7 +123,7 @@ impl<'a> GTPInterpreter<'a> {
             receive_move_from_controller: receive_move_from_controller,
             send_game_to_controller: send_game_to_controller,
             send_halt_to_controller: send_halt_to_controller,
-            timer: Timer::new(),
+            timer: Timer::new(config.clone()),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,10 @@ pub fn main() {
     };
     let mut config = Config::default();
     config.log = log;
-    config.playout = playout::factory(matches.opt_str("p"));
     config.ruleset = ruleset;
     config.threads = threads;
     let config = Arc::new(config);
-    let engine = engine::factory(matches.opt_str("e"), config.clone());
+    let playout = playout::factory(matches.opt_str("p"), config.clone());
+    let engine = engine::factory(matches.opt_str("e"), config.clone(), playout);
     Driver::new(config.clone(), engine);
 }

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -26,16 +26,18 @@ use board::Color;
 use board::Move;
 use board::Pass;
 use board::Play;
+use config::Config;
 
 use rand::{Rng, XorShiftRng};
+use std::sync::Arc;
 
 mod no_eyes;
 mod test;
 
-pub fn factory(opt: Option<String>) -> Box<Playout> {
+pub fn factory(opt: Option<String>, config: Arc<Config>) -> Box<Playout> {
     match opt.as_ref().map(::std::ops::Deref::deref) {
         Some("light") => Box::new(NoEyesPlayout),
-        _             => Box::new(NoSelfAtariPlayout),
+        _             => Box::new(NoSelfAtariPlayout::new(config)),
     }
 }
 
@@ -75,7 +77,7 @@ pub trait Playout: Sync + Send {
             loop {
                 let first = playable_move.unwrap();
                 let r = first + rng.gen::<usize>() % (vacant.len() - first);
-                
+
                 let c = vacant[r];
                 let m = Play(color, c.col, c.row);
                 if board.is_legal(m).is_ok() && self.is_playable(board, &m) {
@@ -87,7 +89,7 @@ pub trait Playout: Sync + Send {
         }
     }
 
-    fn playout_type(&self) -> String;
+    fn playout_type(&self) -> &'static str;
 
 }
 

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -21,22 +21,30 @@
 
 #![cfg(test)]
 
+use config::Config;
+
+use std::sync::Arc;
+
 mod no_eyes;
+
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
 
 #[test]
 fn factory_returns_no_self_atari_by_default() {
-    let playout = super::factory(None);
-    assert_eq!("NoSelfAtariPlayout", playout.playout_type());
+    let playout = super::factory(None, config());
+    assert_eq!("no-self-atari", playout.playout_type());
 }
 
 #[test]
 fn factory_returns_no_self_atari_when_given_any_string() {
-    let playout = super::factory(Some(String::from_str("foo")));
-    assert_eq!("NoSelfAtariPlayout", playout.playout_type());
+    let playout = super::factory(Some(String::from_str("foo")), config());
+    assert_eq!("no-self-atari", playout.playout_type());
 }
 
 #[test]
 fn factory_returns_no_eyes_when_given_light() {
-    let playout = super::factory(Some(String::from_str("light")));
-    assert_eq!("NoEyesPlayout", playout.playout_type());
+    let playout = super::factory(Some(String::from_str("light")), config());
+    assert_eq!("no-eyes", playout.playout_type());
 }

--- a/src/playout/test/no_eyes.rs
+++ b/src/playout/test/no_eyes.rs
@@ -24,12 +24,14 @@
 use board::Black;
 use board::Board;
 use board::Play;
+use config::Config;
 use playout::NoEyesPlayout;
 use playout::NoSelfAtariPlayout;
 use playout::Playout;
 use ruleset::KgsChinese;
 
-use rand::{Rng, weak_rng};
+use rand::weak_rng;
+use std::sync::Arc;
 use test::Bencher;
 
 #[test]
@@ -83,7 +85,7 @@ fn no_eyes_19x19(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_09x09(b: &mut Bencher) {
     let board = Board::new(9, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout;
+    let playout = NoSelfAtariPlayout::new(Arc::new(Config::default()));
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();
@@ -94,7 +96,7 @@ fn no_self_atari_09x09(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_13x13(b: &mut Bencher) {
     let board = Board::new(13, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout;
+    let playout = NoSelfAtariPlayout::new(Arc::new(Config::default()));
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();
@@ -105,7 +107,7 @@ fn no_self_atari_13x13(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_19x19(b: &mut Bencher) {
     let board = Board::new(19, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout;
+    let playout = NoSelfAtariPlayout::new(Arc::new(Config::default()));
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -21,20 +21,26 @@
 
 #![cfg(test)]
 
+use config::Config;
 use game::Info;
 use super::Timer;
 
+use std::sync::Arc;
 use std::thread::sleep_ms;
+
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
 
 #[test]
 fn the_timer_doesnt_start_on_new() {
-    let clock = Timer::new().clock;
+    let clock = Timer::new(config()).clock;
     assert!(clock.stopped());
 }
 
 #[test]
 fn the_timer_has_a_default_of_5_min_sudden_death() {
-    let timer = Timer::new();
+    let timer = Timer::new(config());
     assert_eq!(5*60*1000, timer.main_time);
     assert_eq!(0, timer.byo_time);
     assert_eq!(0, timer.byo_stones);
@@ -42,7 +48,7 @@ fn the_timer_has_a_default_of_5_min_sudden_death() {
 
 #[test]
 fn reset_stops_the_clock_and_resets_everything() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left  = 1;
     timer.byo_time_left   = 1;
     timer.byo_stones_left = 1;
@@ -55,7 +61,7 @@ fn reset_stops_the_clock_and_resets_everything() {
 
 #[test]
 fn update_converts_to_ms_and_resets_everything() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left  = 1;
     timer.byo_time_left   = 1;
     timer.byo_stones_left = 1;
@@ -71,14 +77,14 @@ fn update_converts_to_ms_and_resets_everything() {
 
 #[test]
 fn update_sets_the_main_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.update(1, 0);
     assert_eq!(1000, timer.main_time_left);
 }
 
 #[test]
 fn update_sets_the_byo_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.update(1, 1);
     assert_eq!(0, timer.main_time_left);
     assert_eq!(1000, timer.byo_time_left);
@@ -87,21 +93,21 @@ fn update_sets_the_byo_time() {
 
 #[test]
 fn update_starts_the_clock() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.update(1, 0);
     assert!(timer.clock.running());
 }
 
 #[test]
 fn start_starts_the_clock() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.start();
     assert!(timer.clock.running());
 }
 
 #[test]
 fn stop_changes_the_time_left() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.start();
     sleep_ms(10);
     timer.stop();
@@ -110,14 +116,14 @@ fn stop_changes_the_time_left() {
 
 #[test]
 fn stop_stops_the_clock() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.stop();
     assert!(timer.clock.stopped());
 }
 
 #[test]
 fn adjust_time_updates_the_main_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     assert_eq!(5*60*1000, timer.main_time_left);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000);
@@ -127,7 +133,7 @@ fn adjust_time_updates_the_main_time() {
 
 #[test]
 fn adjust_time_updates_the_byo_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(0, 1, 2);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000);
@@ -138,7 +144,7 @@ fn adjust_time_updates_the_byo_time() {
 
 #[test]
 fn adjust_time_updates_the_byo_stones() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(0, 1, 2);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000);
@@ -148,7 +154,7 @@ fn adjust_time_updates_the_byo_stones() {
 
 #[test]
 fn adjust_time_resets_the_byo_time_after_the_last_move() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(0, 1, 2);
     timer.byo_time_left   = 500;
     timer.byo_stones_left = 1;
@@ -162,7 +168,7 @@ fn adjust_time_resets_the_byo_time_after_the_last_move() {
 
 #[test]
 fn adjust_time_splits_time_between_main_and_byo_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(1, 2, 2);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000*1000*2);
@@ -174,7 +180,7 @@ fn adjust_time_splits_time_between_main_and_byo_time() {
 
 #[test]
 fn adjust_time_sets_remaining_time_to_zero_in_absolute_time_if_time_is_over() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(1, 0, 0);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000*1000*2);
@@ -186,7 +192,7 @@ fn adjust_time_sets_remaining_time_to_zero_in_absolute_time_if_time_is_over() {
 
 #[test]
 fn adjust_time_sets_remaining_time_to_zero_in_byo_time_if_time_is_over() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.setup(0, 1, 0);
     timer.clock.start = Some(0);
     timer.clock.end   = Some(1000000*1000*2);
@@ -218,7 +224,7 @@ impl Info for TestGameInfo {
 
 #[test]
 fn budget_returns_zero_if_the_time_is_over() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left  = 0;
     timer.byo_time_left   = 0;
     timer.byo_stones_left = 0;
@@ -228,7 +234,7 @@ fn budget_returns_zero_if_the_time_is_over() {
 
 #[test]
 fn budget_returns_a_fraction_of_the_byo_time_remaining() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left  = 0;
     timer.byo_time_left   = 2;
     timer.byo_stones_left = 2;
@@ -238,7 +244,7 @@ fn budget_returns_a_fraction_of_the_byo_time_remaining() {
 
 #[test]
 fn budget_rounds_down_when_calculating_the_byo_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left  = 0;
     timer.byo_time_left   = 3;
     timer.byo_stones_left = 2;
@@ -248,7 +254,7 @@ fn budget_rounds_down_when_calculating_the_byo_time() {
 
 #[test]
 fn budget_during_main_time_uses_the_vacant_points_to_calculate_the_time() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left = 10;
     let info = TestGameInfo::new(10);
     assert_eq!(2, timer.budget(&info));
@@ -256,7 +262,7 @@ fn budget_during_main_time_uses_the_vacant_points_to_calculate_the_time() {
 
 #[test]
 fn budget_during_main_time_rounds_down() {
-    let mut timer = Timer::new();
+    let mut timer = Timer::new(config());
     timer.main_time_left = 11;
     let info = TestGameInfo::new(10);
     assert_eq!(2, timer.budget(&info));


### PR DESCRIPTION
This moves the various (potentially) tuneable variables into `Config`. Right now these are only the constant used for calculating the time to use for the next move, the chain size cut off for the self atari playouts, and the expansion threshold for the UCT leaves.