### PR TITLE
have the cutoff moved to 1% so we don't play self-atari

### DIFF
--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -132,14 +132,15 @@ fn finish(root: Node, game: &Game, color: Color, sender: Sender<Move>, config: C
     for halt_sender in halt_senders.iter() {
         halt_sender.send(()).unwrap();
     }
-    if root.all_losses() {
+
+    if root.mostly_losses() {
         if game.winner() == color {
             sender.send(Pass(color)).unwrap();
         } else {
             sender.send(Resign(color)).unwrap();
         }
         if config.log {
-            log!("All simulations were losses");
+            log!("Almost all simulations were losses");
         }
     } else {
         let best_node = root.best();

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -140,11 +140,9 @@ impl Node {
         }
         best
     }
-
-    pub fn all_losses(&self) -> bool {
-        self.children
-            .iter()
-            .all(|n| n.wins == 0)
+    
+    pub fn mostly_losses(&self) -> bool {
+        self.win_ratio() < 0.01
     }
 
     pub fn record_win(&mut self) {


### PR DESCRIPTION
we expect our opponent to ignore self-atari and reward ourselves with 0.0001% winrate and suicide

what we should do is to invoke the seki-checking code (color.winner() thing gives us stones that are not dead on the board, if we're winning with those stones we should pass)