### PR TITLE
Reuse subtree in uct search

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -19,5 +19,5 @@ TIME="5m"
 
 gogui-twogtp -auto -black "$GNUGO" -white "$IOMRASCALAI" \
              -size $SIZE -alternate -games $GAMES -sgffile gnugo-benchmark \
-             -time $TIME -referee "$REFEREE" -verbose
+             -time $TIME -referee "$REFEREE" -verbose -debugtocomment
 gogui-twogtp -analyze gnugo-benchmark.dat

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,7 +6,7 @@ cd "$DIR/.."
 set -ex
 
 cargo build --release
-rm -f *benchmark*
+# rm -f *benchmark*
 
 THREADS=8
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -5,8 +5,10 @@ cd "$DIR/.."
 
 set -ex
 
+FN="gnugo-benchmark"
+
 cargo build --release
-rm -f *benchmark*
+rm -f $FN*
 
 THREADS=8
 
@@ -18,6 +20,6 @@ GAMES=100
 TIME="5m"
 
 gogui-twogtp -auto -black "$GNUGO" -white "$IOMRASCALAI" \
-             -size $SIZE -alternate -games $GAMES -sgffile gnugo-benchmark \
+             -size $SIZE -alternate -games $GAMES -sgffile $FN \
              -time $TIME -referee "$REFEREE" -verbose -debugtocomment
-gogui-twogtp -analyze gnugo-benchmark.dat
+gogui-twogtp -analyze $FN.dat

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,7 +6,7 @@ cd "$DIR/.."
 set -ex
 
 cargo build --release
-# rm -f *benchmark*
+rm -f *benchmark*
 
 THREADS=8
 

--- a/bin/play
+++ b/bin/play
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DIR=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+cd "$DIR/.."
+
+set -ex
+
+cargo build --release
+
+IOMRASCALAI="./target/release/iomrascalai -t 8 -l"
+SIZE=5
+
+gogui -computer-black -program "$IOMRASCALAI" -size $SIZE

--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -8,7 +8,7 @@ set -ex
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-IOMRASCALAI="./target/release/iomrascalai -e $1 -t 8 -l"
+IOMRASCALAI="./target/release/iomrascalai -t 8 -l"
 SIZE=9
 TIME="5m"
 

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -26,6 +26,7 @@ pub use self::Color::White;
 pub use self::chain::Chain;
 pub use self::coord::Coord;
 pub use self::movement::Move;
+pub use self::movement::NoMove;
 pub use self::movement::Pass;
 pub use self::movement::Play;
 pub use self::movement::Resign;
@@ -337,23 +338,23 @@ impl Board {
         self.play_legal_move(m);
         Ok(())
     }
-    
+
     //always called on moves that are already known to be legal
     pub fn play_legal_move(&mut self, m: Move) {
         self.previous_player = *m.color();
-        
+
         if m.is_pass() {
             self.consecutive_passes += 1;
             return;
         } else {
             self.consecutive_passes = 0;
         }
-        
+
         if m.is_resign() {
             self.resigned_by = *m.color();
             return;
         }
-        
+
         // Create new chain or merge it with the neighbouring ones. It
         // removes coord from the list of liberties of the
         // neighbouring chains.
@@ -377,8 +378,8 @@ impl Board {
         }
         self.update_vacant(&m);
     }
-    
-    
+
+
     //#[inline(never)] //turn off for profiling
     fn update_vacant(&mut self, m: &Move) {
         let pos = self.vacant.iter().position(|&c| c == m.coord()).unwrap();

--- a/src/board/movement/mod.rs
+++ b/src/board/movement/mod.rs
@@ -22,6 +22,7 @@
 pub use self::Move::Pass;
 pub use self::Move::Play;
 pub use self::Move::Resign;
+pub use self::Move::NoMove;
 use board::Color;
 use board::Coord;
 
@@ -29,6 +30,7 @@ mod test;
 
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
 pub enum Move {
+    NoMove,
     Pass(Color),
     Play(Color, u8, u8),
     Resign(Color),
@@ -54,6 +56,7 @@ impl Move {
             Pass(_)           => String::from_str("pass"),
             Play(_, col, row) => Coord::new(col, row).to_gtp(),
             Resign(_)         => String::from_str("resign"),
+            NoMove            => panic!("Can't turn Move::NoMove into a GTP move!"),
         }
     }
 
@@ -63,6 +66,7 @@ impl Move {
             Play(ref c, _, _) => c,
             Pass(ref c)       => c,
             Resign(ref c)     => c,
+            NoMove            => panic!("Move::NoMove has no color!"),
         }
     }
 
@@ -72,6 +76,7 @@ impl Move {
             Play(_, col, row) => Coord::new(col, row),
             Pass(_)           => panic!("You have tried to get the coord() of a Pass move"),
             Resign(_)         => panic!("You have tried to get the coord() of a Resign"),
+            NoMove            => panic!("You have tried to get the coord() of a NoMove"),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ use ruleset::Ruleset;
 pub struct UctConfig {
     pub end_of_game_cutoff: f32,
     pub expand_after: usize,
+    pub reuse_subtree: bool,
     pub tuned: bool,
 }
 
@@ -65,6 +66,7 @@ impl Config {
             uct: UctConfig {
                 end_of_game_cutoff: 0.01,
                 expand_after: 1,
+                reuse_subtree: true,
                 tuned: true,
             },
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ pub struct PlayoutConfig {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Config {
+    pub debug: bool,
     pub log: bool,
     pub playout: PlayoutConfig,
     pub ruleset: Ruleset,
@@ -54,6 +55,7 @@ impl Config {
 
     pub fn default() -> Config {
         Config {
+            debug: true,
             log: false,
             playout: PlayoutConfig {
                 no_self_atari_cutoff: 7,

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -48,10 +48,6 @@ impl<'a> EngineController<'a> {
         }
     }
 
-    pub fn play_move(&mut self, m: Move) {
-        self.engine.play(m);
-    }
-
     pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &Timer, send_move: Sender<Move>) {
         let budget = self.budget(timer, game);
         let (send_move_to_controller, receive_move_from_engine) = channel();

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -48,6 +48,10 @@ impl<'a> EngineController<'a> {
         }
     }
 
+    pub fn play_move(&self, m: Move) {
+        self.engine.play(m);
+    }
+
     pub fn run_and_return_move(&self, color: Color, game: &Game, timer: &Timer, send_move: Sender<Move>) {
         let budget = self.budget(timer, game);
         let (send_move_to_controller, receive_move_from_engine) = channel();

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -48,6 +48,10 @@ impl<'a> EngineController<'a> {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.engine.reset();
+    }
+
     pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &Timer, send_move: Sender<Move>) {
         let budget = self.budget(timer, game);
         let (send_move_to_controller, receive_move_from_engine) = channel();

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -48,11 +48,11 @@ impl<'a> EngineController<'a> {
         }
     }
 
-    pub fn play_move(&self, m: Move) {
+    pub fn play_move(&mut self, m: Move) {
         self.engine.play(m);
     }
 
-    pub fn run_and_return_move(&self, color: Color, game: &Game, timer: &Timer, send_move: Sender<Move>) {
+    pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &Timer, send_move: Sender<Move>) {
         let budget = self.budget(timer, game);
         let (send_move_to_controller, receive_move_from_engine) = channel();
         let (send_signal_to_engine, receive_signal_from_controller) = channel::<()>();

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -53,7 +53,7 @@ impl EarlyReturnEngine {
 
 impl Engine for EarlyReturnEngine {
 
-    fn gen_move(&self, c: Color, _: &Game, sender: Sender<Move>, _: Receiver<()>) {
+    fn gen_move(&mut self, c: Color, _: &Game, sender: Sender<Move>, _: Receiver<()>) {
         sender.send(Pass(c));
     }
 
@@ -66,7 +66,7 @@ fn the_engine_can_use_less_time_than_allocated() {
     let timer = Timer::new(config());
     let budget = timer.budget(&game);
     let engine = Box::new(EarlyReturnEngine::new());
-    let controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(Config::default(), engine);
     let start_time = PreciseTime::now();
     let (sender, receiver) = channel::<Move>();
     controller.run_and_return_move(color, &game, &timer, sender);
@@ -88,7 +88,7 @@ impl WaitingEngine {
 
 impl Engine for WaitingEngine {
 
-    fn gen_move(&self, c: Color, _: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+    fn gen_move(&mut self, c: Color, _: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
         select!(
             _ = receiver.recv() => { sender.send(Pass(c)); }
         )
@@ -105,7 +105,7 @@ fn the_controller_asks_the_engine_for_a_move_when_the_time_is_up() {
     timer.setup(1, 0, 0);
     let budget = timer.budget(&game);
     let engine = Box::new(WaitingEngine::new());
-    let controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(Config::default(), engine);
     let start_time = PreciseTime::now();
     let (sender, receiver) = channel::<Move>();
     controller.run_and_return_move(color, &game, &timer, sender);

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -49,7 +49,7 @@ impl AmafMcEngine {
 
 impl Engine for AmafMcEngine {
 
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+    fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
         super::gen_move::<AmafMcEngine>(self.config, self.playout.clone(), color, game, sender, receiver);
     }
 

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -49,7 +49,7 @@ impl SimpleMcEngine {
 
 impl Engine for SimpleMcEngine {
 
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+    fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
         super::gen_move::<SimpleMcEngine>(self.config, self.playout.clone(), color, game, sender, receiver);
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -60,7 +60,6 @@ pub fn factory(opt: Option<String>, config: Config, playout: Box<Playout>) -> Bo
 pub trait Engine: Send + Sync {
 
     fn gen_move(&mut self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
-    fn play(&mut self, Move) {}
     fn engine_type(&self) -> &'static str {
         ""
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -60,6 +60,7 @@ pub fn factory(opt: Option<String>, config: Config, playout: Box<Playout>) -> Bo
 pub trait Engine: Send + Sync {
 
     fn gen_move(&self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
+    fn play(&self, Move) {}
     fn engine_type(&self) -> &'static str {
         ""
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -63,5 +63,6 @@ pub trait Engine: Send + Sync {
     fn engine_type(&self) -> &'static str {
         ""
     }
+    fn reset(&mut self) {}
 
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -59,8 +59,8 @@ pub fn factory(opt: Option<String>, config: Config, playout: Box<Playout>) -> Bo
 
 pub trait Engine: Send + Sync {
 
-    fn gen_move(&self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
-    fn play(&self, Move) {}
+    fn gen_move(&mut self, Color, &Game, sender: Sender<Move>, receiver: Receiver<()>);
+    fn play(&mut self, Move) {}
     fn engine_type(&self) -> &'static str {
         ""
     }

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -40,7 +40,7 @@ impl RandomEngine {
 
 impl Engine for RandomEngine {
 
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, _: Receiver<()>) {
+    fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, _: Receiver<()>) {
         let mut moves = game.legal_moves();
         moves.push(Pass(color));
         let m = moves[random::<usize>() % moves.len()];

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -76,8 +76,15 @@ impl Engine for UctEngine {
             // Needed for the first reusal. Otherwise it's 0 and we
             // get a percentage of inf.
             self.previous_node_count = self.root.descendants();
-            self.set_new_root(game.last_move(), color);
-            self.root.remove_illegal_children(game);
+            // We don't currently include pass moves in the tree, so
+            // we need to handle the case where the opponent plays a
+            // pass move separately.
+            if game.last_move().is_pass() {
+                self.root = Node::root(game, color);
+            } else {
+                self.set_new_root(game.last_move(), color);
+                self.root.remove_illegal_children(game);
+            }
             let reused_node_count = self.root.descendants();
             if self.config.log {
                 let percentage = reused_node_count as f32 / self.previous_node_count as f32;

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -60,6 +60,11 @@ impl UctEngine {
     fn set_new_root(&mut self, m: Move) {
         let new_root = self.root.find_child(m);
         self.root = new_root;
+        // Set these values to zero, as the new root is actually a
+        // node of the opponent. Otherwise the win ratio would
+        // approach 0% as we win the game. And then we would resign!
+        self.root.plays = 0;
+        self.root.wins = 0;
     }
 
 }
@@ -72,12 +77,6 @@ impl Engine for UctEngine {
         } else {
             self.set_new_root(game.last_move());
         }
-        if self.config.log {
-            let rm = self.root.m();
-            log!("Continuing with {:?} {} ({} simulations, {}% wins on average)", rm.color(), rm.to_gtp(), self.root.plays()-1, self.root.win_ratio()*100.0);
-
-        }
-
         if self.root.has_no_children() {
             if self.config.log {
                 log!("No moves to simulate!");

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -76,14 +76,14 @@ impl Engine for UctEngine {
             // Needed for the first reusal. Otherwise it's 0 and we
             // get a percentage of inf.
             self.previous_node_count = self.root.descendants();
+            self.set_new_root(game.last_move(), color);
+            self.root.remove_illegal_children(game);
             // We don't currently include pass moves in the tree, so
             // we need to handle the case where the opponent plays a
             // pass move separately.
-            if game.last_move().is_pass() {
+            if self.root.has_no_children() {
                 self.root = Node::root(game, color);
             } else {
-                self.set_new_root(game.last_move(), color);
-                self.root.remove_illegal_children(game);
                 let reused_node_count = self.root.descendants();
                 if self.config.log {
                     let percentage = reused_node_count as f32 / self.previous_node_count as f32;

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -58,10 +58,8 @@ impl UctEngine {
     }
 
     fn set_new_root(&mut self, m: Move) {
-        if self.root.m() != Pass(Empty) {
-            let new_root = self.root.find_child(m);
-            self.root = new_root;
-        }
+        let new_root = self.root.find_child(m);
+        self.root = new_root;
     }
 
 }
@@ -71,7 +69,15 @@ impl Engine for UctEngine {
     fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
         if self.root.m() == Pass(Empty) {
             self.root = Node::root(game, color);
+        } else {
+            self.set_new_root(game.last_move());
         }
+        if self.config.log {
+            let rm = self.root.m();
+            log!("Continuing with {:?} {} ({} simulations, {}% wins on average)", rm.color(), rm.to_gtp(), self.root.plays()-1, self.root.win_ratio()*100.0);
+
+        }
+
         if self.root.has_no_children() {
             if self.config.log {
                 log!("No moves to simulate!");
@@ -96,10 +102,6 @@ impl Engine for UctEngine {
                 }
                 )
         }
-    }
-
-    fn play(&mut self, m: Move) {
-        self.set_new_root(m);
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -43,20 +43,28 @@ mod node;
 
 pub struct UctEngine {
     config: Config,
+    gen_moves: usize,
     playout: Arc<Box<Playout>>,
+    plays: usize,
 }
 
 impl UctEngine {
 
     pub fn new(config: Config, playout: Box<Playout>) -> UctEngine {
-        UctEngine { config: config, playout: Arc::new(playout) }
+        UctEngine {
+            config: config,
+            gen_moves: 0,
+            playout: Arc::new(playout),
+            plays: 0,
+        }
     }
 
 }
 
 impl Engine for UctEngine {
 
-    fn gen_move(&self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+    fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+        self.gen_moves += 1; // dummy field to test making the engines mutable
         let mut root = Node::root(game, color);
         if root.has_no_children() {
             if self.config.log {
@@ -81,6 +89,10 @@ impl Engine for UctEngine {
                 }
                 )
         }
+    }
+
+    fn play(&mut self, _: Move) {
+        self.plays += 1; // Dummy field to test making the engines mutable
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -84,13 +84,13 @@ impl Engine for UctEngine {
             } else {
                 self.set_new_root(game.last_move(), color);
                 self.root.remove_illegal_children(game);
+                let reused_node_count = self.root.descendants();
+                if self.config.log {
+                    let percentage = reused_node_count as f32 / self.previous_node_count as f32;
+                    log!("Reusing {} nodes ({}%)", reused_node_count, percentage*100.0)
+                }
             }
-            let reused_node_count = self.root.descendants();
-            if self.config.log {
-                let percentage = reused_node_count as f32 / self.previous_node_count as f32;
-                log!("Reusing {} nodes ({}%)", reused_node_count, percentage*100.0)
-            }
-            self.previous_node_count = reused_node_count;
+            self.previous_node_count = self.root.descendants();
         }
         if self.root.has_no_children() {
             if self.config.log {

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -113,6 +113,12 @@ impl Engine for UctEngine {
     fn engine_type(&self) -> &'static str {
         "uct"
     }
+
+    fn reset(&mut self) {
+        self.previous_node_count = 0;
+        self.root = Node::new(NoMove);
+    }
+
 }
 
 fn spin_up<'a>(config: Config, playout: Arc<Box<Playout>>, game: &Game, send_to_main: Sender<((Vec<usize>, Color, usize), Sender<(Vec<usize>, Vec<Move>, bool, usize)>)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -23,6 +23,7 @@ use board::Board;
 use board::Color;
 use board::Empty;
 use board::Move;
+use board::NoMove;
 use board::Pass;
 use board::Resign;
 use config::Config;
@@ -53,7 +54,7 @@ impl UctEngine {
         UctEngine {
             config: config,
             playout: Arc::new(playout),
-            root: Node::new(Pass(Empty)),
+            root: Node::new(NoMove),
         }
     }
 
@@ -67,7 +68,7 @@ impl UctEngine {
 impl Engine for UctEngine {
 
     fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        if self.root.m() == Pass(Empty) {
+        if self.root.m() == NoMove {
             self.root = Node::root(game, color);
         } else {
             self.set_new_root(game.last_move(), color);

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -77,6 +77,7 @@ impl Engine for UctEngine {
             // get a percentage of inf.
             self.previous_node_count = self.root.descendants();
             self.set_new_root(game.last_move(), color);
+            self.root.remove_illegal_children(game);
             let reused_node_count = self.root.descendants();
             if self.config.log {
                 let percentage = reused_node_count as f32 / self.previous_node_count as f32;

--- a/src/engine/uct/mod.rs
+++ b/src/engine/uct/mod.rs
@@ -68,7 +68,7 @@ impl UctEngine {
 impl Engine for UctEngine {
 
     fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        if self.root.m() == NoMove {
+        if !self.config.uct.reuse_subtree || self.root.m() == NoMove {
             self.root = Node::root(game, color);
         } else {
             self.set_new_root(game.last_move(), color);

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -61,6 +61,18 @@ impl Node {
         root
     }
 
+    pub fn make_root(&mut self, color: Color) {
+        // Set these values to zero, as the new root is actually a
+        // node of the opponent. Otherwise the win ratio would
+        // approach 0% as we win the game. And then we would resign!
+        self.plays = 0;
+        self.wins = 0;
+        // The root has to have the color of the player we want to
+        // simulate. Otherwise the win statistics are for the wrong
+        // player!
+        self.m = Pass(color);
+    }
+
     pub fn find_leaf_and_expand(&mut self, game: &Game, expand_after: usize, tuned: bool) -> (Vec<usize>, Vec<Move>, bool) {
         let (path, moves, leaf) = self.find_leaf_and_mark(vec!(), vec!(), tuned);
         let mut board = game.board();

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -75,6 +75,19 @@ impl Node {
         self.m = Pass(color);
     }
 
+    pub fn remove_illegal_children(&mut self, game: &Game) {
+        let mut to_remove = vec!();
+        for (index, node) in self.children.iter().enumerate() {
+            if game.play(node.m()).is_err() {
+                to_remove.push(index);
+            }
+        }
+        to_remove.reverse();
+        for &index in to_remove.iter() {
+            self.children.remove(index);
+        }
+    }
+
     pub fn find_leaf_and_expand(&mut self, game: &Game, expand_after: usize, tuned: bool) -> (Vec<usize>, Vec<Move>, bool, usize) {
         let (path, moves, leaf) = self.find_leaf_and_mark(vec!(), vec!(), tuned);
         let mut board = game.board();

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -186,6 +186,10 @@ impl Node {
         self.plays
     }
 
+    pub fn descendants(&self) -> usize {
+        self.descendants
+    }
+
     pub fn find_child(&self, m: Move) -> Node {
         match self.children.iter().find(|c| c.m() == m) {
             Some(node) => node.clone(),

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -84,6 +84,7 @@ impl Node {
         }
         to_remove.reverse();
         for &index in to_remove.iter() {
+            self.descendants -= self.children[index].descendants;
             self.children.remove(index);
         }
     }

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -63,6 +63,21 @@ impl Node {
         root
     }
 
+    pub fn find_new_root(&self, game: &Game, color: Color) -> Node {
+        let mut new_root = self.find_child(game.last_move());
+        new_root.make_root(color);
+        new_root.remove_illegal_children(game);
+        // We don't currently include pass moves in the tree, so
+        // we need to handle the case where the opponent plays a
+        // pass move separately. This branch also handles the
+        // first move where we don't have a tree, yet.
+        if new_root.has_no_children() {
+            Node::root(game, color)
+        } else {
+            new_root
+        }
+    }
+
     pub fn make_root(&mut self, color: Color) {
         // Set these values to zero, as the new root is actually a
         // node of the opponent. Otherwise the win ratio would

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -21,6 +21,7 @@
 
 use board::Board;
 use board::Color;
+use board::Empty;
 use board::Move;
 use board::Pass;
 use game::Game;
@@ -163,7 +164,10 @@ impl Node {
     }
 
     pub fn find_child(&self, m: Move) -> Node {
-        self.children.iter().find(|c| c.m() == m).unwrap().clone()
+        match self.children.iter().find(|c| c.m() == m) {
+            Some(node) => node.clone(),
+            None => Node::new(Pass(Empty)),
+        }
     }
 
     fn next_uct_tuned_child_index(&self) -> usize {

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -30,6 +30,7 @@ use std::usize;
 
 mod test;
 
+#[derive(Clone)]
 pub struct Node {
     children: Vec<Node>,
     m: Move,
@@ -159,6 +160,10 @@ impl Node {
 
     pub fn plays(&self) -> usize {
         self.plays
+    }
+
+    pub fn find_child(&self, m: Move) -> Node {
+        self.children.iter().find(|c| c.m() == m).unwrap().clone()
     }
 
     fn next_uct_tuned_child_index(&self) -> usize {

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -31,7 +31,7 @@ use std::usize;
 
 mod test;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Node {
     children: Vec<Node>,
     m: Move,

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -21,8 +21,8 @@
 
 use board::Board;
 use board::Color;
-use board::Empty;
 use board::Move;
+use board::NoMove;
 use board::Pass;
 use game::Game;
 
@@ -178,7 +178,7 @@ impl Node {
     pub fn find_child(&self, m: Move) -> Node {
         match self.children.iter().find(|c| c.m() == m) {
             Some(node) => node.clone(),
-            None => Node::new(Pass(Empty)),
+            None => Node::new(NoMove),
         }
     }
 

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -132,6 +132,13 @@ fn record_on_path_only_records_wins_for_the_correct_color() {
     assert_eq!(1, root.children[0].children[0].wins);
 }
 
+#[test]
+fn find_child_returns_the_correct_child() {
+    let mut root = Node::new(Pass(Black));
+    let child = Node::new(Play(White, 1, 1));
+    root.children = vec!(Node::new(Play(Black, 5, 5)), child.clone(), Node::new(Play(Black, 3, 7)));
+    assert_eq!(child, root.find_child(Play(White, 1, 1)));
+}
 
 // 2. Make sure that terminal nodes are "played", i.e. either a win or
 //    a loss is reported and the wins are recorded in the tree.

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -89,11 +89,19 @@ fn find_leaf_and_expand_expands_the_leaves() {
 }
 
 #[test]
-fn run_playout_sets_play_on_the_root() {
+fn find_leaf_and_expand_sets_play_on_the_root() {
     let game = Game::new(2, 0.5, KgsChinese);
     let mut root = Node::root(&game, Black);
     root.find_leaf_and_expand(&game, 1, false);
     assert_eq!(2, root.plays);
+}
+
+#[test]
+fn find_leaf_and_expand_returns_the_number_of_nodes_added() {
+    let game = Game::new(2, 0.5, KgsChinese);
+    let mut root = Node::root(&game, Black);
+    let (_,_,_,count) = root.find_leaf_and_expand(&game, 1, false);
+    assert_eq!(3, count);
 }
 
 #[test]
@@ -121,15 +129,33 @@ fn record_on_path_only_records_wins_for_the_correct_color() {
     let mut root = Node::new(Pass(Black));
     root.children = vec!(child);
 
-    root.record_on_path(&vec!(0, 0), Black);
+    root.record_on_path(&vec!(0, 0), Black, 0);
     assert_eq!(1, root.wins);
     assert_eq!(0, root.children[0].wins);
     assert_eq!(1, root.children[0].children[0].wins);
 
-    root.record_on_path(&vec!(0, 0), White);
+    root.record_on_path(&vec!(0, 0), White, 0);
     assert_eq!(1, root.wins);
     assert_eq!(1, root.children[0].wins);
     assert_eq!(1, root.children[0].children[0].wins);
+}
+
+#[test]
+fn record_on_path_updates_the_descendant_counts() {
+    let mut grandchild = Node::new(Pass(Black));
+    // The leaf already has the correct value set
+    grandchild.descendants = 5;
+    let mut child = Node::new(Pass(White));
+    child.children = vec!(grandchild);
+    child.descendants = 1;
+    let mut root = Node::new(Pass(Black));
+    root.children = vec!(child);
+    root.descendants = 2;
+
+    root.record_on_path(&vec!(0, 0), Black, 5);
+    assert_eq!(7, root.descendants);
+    assert_eq!(6, root.children[0].descendants);
+    assert_eq!(5, root.children[0].children[0].descendants);
 }
 
 #[test]
@@ -139,6 +165,30 @@ fn find_child_returns_the_correct_child() {
     root.children = vec!(Node::new(Play(Black, 5, 5)), child.clone(), Node::new(Play(Black, 3, 7)));
     assert_eq!(child, root.find_child(Play(White, 1, 1)));
 }
+
+#[test]
+fn new_sets_the_descendats_to_zero() {
+    let node = Node::new(Pass(Black));
+    assert_eq!(0, node.descendants);
+}
+
+#[test]
+fn expand_root_sets_the_correct_descendant_count_on_the_root() {
+    let game = Game::new(5, 6.5, KgsChinese);
+    let mut root = Node::new(Pass(Black));
+    root.expand_root(&game);
+    assert_eq!(25, root.descendants);
+}
+
+#[test]
+fn expand_sets_the_descendant_count_if_the_node_was_expanded() {
+    let game = Game::new(5, 6.5, KgsChinese);
+    let board = game.board();
+    let mut node = Node::new(Pass(Black));
+    node.expand(&board, 0);
+    assert_eq!(25, node.descendants);
+}
+
 
 // 2. Make sure that terminal nodes are "played", i.e. either a win or
 //    a loss is reported and the wins are recorded in the tree.

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -23,10 +23,9 @@
 use board::Board;
 use board::Color;
 use board::Coord;
-use board::Empty;
 use board::IllegalMove;
 use board::Move;
-use board::Pass;
+use board::NoMove;
 use ruleset::Ruleset;
 use score::Score;
 use self::zobrist_hash_table::ZobristHashTable;
@@ -58,7 +57,7 @@ impl Game {
 
         Game {
             board: new_board,
-            last_move: Pass(Empty),
+            last_move: NoMove,
             move_number: 0,
             zobrist_hash_table: ZobristHashTable::new(size),
         }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -23,8 +23,10 @@
 use board::Board;
 use board::Color;
 use board::Coord;
+use board::Empty;
 use board::IllegalMove;
 use board::Move;
+use board::Pass;
 use ruleset::Ruleset;
 use score::Score;
 use self::zobrist_hash_table::ZobristHashTable;
@@ -45,6 +47,7 @@ pub trait Info {
 #[derive(Clone)]
 pub struct Game {
     board: Board,
+    last_move: Move,
     move_number: u16,
     zobrist_hash_table: ZobristHashTable,
 }
@@ -55,16 +58,18 @@ impl Game {
 
         Game {
             board: new_board,
+            last_move: Pass(Empty),
             move_number: 0,
             zobrist_hash_table: ZobristHashTable::new(size),
         }
     }
 
-    pub fn with_new_state(board: Board, move_number: u16, zobrist_hash_table: ZobristHashTable ) -> Game {
+    pub fn with_new_state(board: Board, move_number: u16, zobrist_hash_table: ZobristHashTable, last_move: Move) -> Game {
         Game {
-            board:                  board,
-            move_number:            move_number,
-            zobrist_hash_table:     zobrist_hash_table
+            board: board,
+            last_move: last_move,
+            move_number: move_number,
+            zobrist_hash_table: zobrist_hash_table,
        }
     }
 
@@ -73,7 +78,7 @@ impl Game {
 
         match new_board.play(m) {
             Ok(_) => {
-                let mut new_game_state = Game::with_new_state(new_board, self.move_number + 1, self.zobrist_hash_table.clone());
+                let mut new_game_state = Game::with_new_state(new_board, self.move_number + 1, self.zobrist_hash_table.clone(), m);
                 if !m.is_pass() && !m.is_resign() {
                     match new_game_state.check_and_update_super_ko(&m) {
                         Err(_) => return Err(IllegalMove::SuperKo),
@@ -102,6 +107,10 @@ impl Game {
 
     pub fn move_number(&self) -> u16 {
         self.move_number
+    }
+
+    pub fn last_move(&self) -> Move {
+        self.last_move
     }
 
     pub fn is_over(&self) -> bool {

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -106,7 +106,7 @@ impl<'a> GTPInterpreter<'a> {
         let (send_halt_to_controller, receive_halt_from_interpreter) = channel::<()>();
         let controller_config = config;
         let guard = thread::scoped(move || {
-            let controller = EngineController::new(controller_config, engine);
+            let mut controller = EngineController::new(controller_config, engine);
             loop {
                 select!(data = receive_game_from_interpreter.recv() => {
                     let (game, color, timer) = data.unwrap();

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -92,7 +92,6 @@ pub struct GTPInterpreter<'a> {
     receive_move_from_controller: Receiver<Move>,
     send_game_to_controller: Sender<(Game, Color, Timer)>,
     send_halt_to_controller: Sender<()>,
-    send_play_to_controller: Sender<Move>,
     timer: Timer,
 }
 
@@ -102,23 +101,19 @@ impl<'a> GTPInterpreter<'a> {
         let boardsize = 19;
         let (send_game_to_controller, receive_game_from_interpreter) = channel::<(Game, Color, Timer)>();
         let (send_move_to_interpreter, receive_move_from_controller) = channel::<Move>();
-        let (send_play_to_controller, receive_play_from_interpreter) = channel::<Move>();
         let (send_halt_to_controller, receive_halt_from_interpreter) = channel::<()>();
         let controller_config = config;
         let guard = thread::scoped(move || {
             let mut controller = EngineController::new(controller_config, engine);
             loop {
-                select!(data = receive_game_from_interpreter.recv() => {
-                    let (game, color, timer) = data.unwrap();
-                    controller.run_and_return_move(color, &game, &timer, send_move_to_interpreter.clone());
-                },
-                        data = receive_play_from_interpreter.recv() => {
-                            let m = data.unwrap();
-                            controller.play_move(m);
-                        },
-                        _ = receive_halt_from_interpreter.recv() => {
-                            break;
-                        })
+                select!(
+                    data = receive_game_from_interpreter.recv() => {
+                        let (game, color, timer) = data.unwrap();
+                        controller.run_and_return_move(color, &game, &timer, send_move_to_interpreter.clone());
+                    },
+                    _ = receive_halt_from_interpreter.recv() => {
+                        break;
+                    })
             }
         });
         GTPInterpreter {
@@ -128,7 +123,6 @@ impl<'a> GTPInterpreter<'a> {
             receive_move_from_controller: receive_move_from_controller,
             send_game_to_controller: send_game_to_controller,
             send_halt_to_controller: send_halt_to_controller,
-            send_play_to_controller: send_play_to_controller,
             timer: Timer::new(config),
         }
     }
@@ -237,7 +231,6 @@ impl<'a> GTPInterpreter<'a> {
                     match self.game.play(m) {
                         Ok(g) => {
                             self.game = g;
-                            self.send_play_to_controller.send(m).unwrap();
                             Command::Play
                         },
                         Err(e) => {

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -85,13 +85,18 @@ pub enum Command {
     Version,
 }
 
+pub enum ControllerCommand {
+    GenMove(Game, Color, Timer),
+    Reset,
+    ShutDown,
+}
+
 pub struct GTPInterpreter<'a> {
     _guard: thread::JoinGuard<'a, ()>,
     config: Config,
     game: Game,
     receive_move_from_controller: Receiver<Move>,
-    send_game_to_controller: Sender<(Game, Color, Timer)>,
-    send_halt_to_controller: Sender<()>,
+    send_command_to_controller: Sender<ControllerCommand>,
     timer: Timer,
 }
 
@@ -99,21 +104,26 @@ impl<'a> GTPInterpreter<'a> {
     pub fn new(config: Config, engine: Box<Engine>) -> GTPInterpreter<'a> {
         let komi      = 6.5;
         let boardsize = 19;
-        let (send_game_to_controller, receive_game_from_interpreter) = channel::<(Game, Color, Timer)>();
+        let (send_command_to_controller, receive_command_from_interpreter) = channel::<ControllerCommand>();
         let (send_move_to_interpreter, receive_move_from_controller) = channel::<Move>();
-        let (send_halt_to_controller, receive_halt_from_interpreter) = channel::<()>();
         let controller_config = config;
         let guard = thread::scoped(move || {
             let mut controller = EngineController::new(controller_config, engine);
             loop {
-                select!(
-                    data = receive_game_from_interpreter.recv() => {
-                        let (game, color, timer) = data.unwrap();
-                        controller.run_and_return_move(color, &game, &timer, send_move_to_interpreter.clone());
+                match receive_command_from_interpreter.recv() {
+                    Ok(command) => {
+                        match command {
+                            ControllerCommand::GenMove(game, color, timer) => {
+                                controller.run_and_return_move(color, &game, &timer, send_move_to_interpreter.clone());
+                            },
+                            ControllerCommand::Reset => {
+                                controller.reset();
+                            }
+                            ControllerCommand::ShutDown => { break; },
+                        }
                     },
-                    _ = receive_halt_from_interpreter.recv() => {
-                        break;
-                    })
+                    Err(_) => { break; }
+                }
             }
         });
         GTPInterpreter {
@@ -121,14 +131,13 @@ impl<'a> GTPInterpreter<'a> {
             config: config,
             game: Game::new(boardsize, komi, config.ruleset),
             receive_move_from_controller: receive_move_from_controller,
-            send_game_to_controller: send_game_to_controller,
-            send_halt_to_controller: send_halt_to_controller,
+            send_command_to_controller: send_command_to_controller,
             timer: Timer::new(config),
         }
     }
 
     pub fn quit(&self) {
-        self.send_halt_to_controller.send(()).unwrap();
+        self.send_command_to_controller.send(ControllerCommand::ShutDown).unwrap();
     }
 
     pub fn game<'b>(&'b self) -> &'b Game {
@@ -193,6 +202,7 @@ impl<'a> GTPInterpreter<'a> {
             KnownCommands::clear_board      => {
                 self.game = Game::new(self.boardsize(), self.komi(), self.ruleset());
                 self.timer.reset();
+                self.send_command_to_controller.send(ControllerCommand::Reset).unwrap();
                 Command::ClearBoard
             },
             KnownCommands::komi             => match command.get(1) {
@@ -210,7 +220,8 @@ impl<'a> GTPInterpreter<'a> {
         	Some(comm) => {
                     self.timer.start();
         	    let color = Color::from_gtp(comm);
-                    self.send_game_to_controller.send((self.game.clone(), color, self.timer.clone())).unwrap();
+                    let command = ControllerCommand::GenMove(self.game.clone(), color, self.timer.clone());
+                    self.send_command_to_controller.send(command).unwrap();
                     let m = self.receive_move_from_controller.recv().unwrap();
                     match self.game.play(m) {
                         Ok(g) => {

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -140,14 +140,6 @@ fn play_plays_a_move() {
 }
 
 #[test]
-fn play_notifies_the_engine_of_the_move() {
-    // Build a special engine for this and then maybe use std::cell to
-    // make sure it was called. Or maybe make the methods on the
-    // engine mutable. We'll need that later on anyway.
-    assert!(false);
-}
-
-#[test]
 fn sets_the_komi() {
     let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("komi 10\n");

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -140,6 +140,14 @@ fn play_plays_a_move() {
 }
 
 #[test]
+fn play_notifies_the_engine_of_the_move() {
+    // Build a special engine for this and then maybe use std::cell to
+    // make sure it was called. Or maybe make the methods on the
+    // engine mutable. We'll need that later on anyway.
+    assert!(false);
+}
+
+#[test]
 fn sets_the_komi() {
     let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
     interpreter.read("komi 10\n");


### PR DESCRIPTION
This is a preview of the new code to reuse the subtree of the UCT search for the next search. It seems to work, but it exhibits a somewhat weird behaviour. Unlike before the win ratio of the best move and the average drift apart. There's probably still a bug in there as a win ratio of 0% for the best move and some positive value for the average is somewhat unlikely. ;)