### PR TITLE
Remove inline compiler hints

### DIFF
--- a/src/board/chain/mod.rs
+++ b/src/board/chain/mod.rs
@@ -43,12 +43,10 @@ impl Chain {
         }
     }
 
-    #[inline(always)]
     pub fn coords<'a>(&'a self) -> &'a Vec<Coord> {
         &self.coords
     }
 
-    #[inline(always)]
     pub fn liberties(&self) -> &HashSet<Coord> {
         &self.libs
     }
@@ -61,22 +59,18 @@ impl Chain {
         self.id = id;
     }
 
-    #[inline(always)]
     pub fn add_liberty(&mut self, coord: Coord) {
         self.libs.insert(coord);
     }
 
-    #[inline(always)]
     pub fn remove_liberty(&mut self, coord: Coord) {
         self.libs.remove(&coord);
     }
 
-    #[inline(always)]
     pub fn add_coord(&mut self, coord: Coord) {
         self.coords.push(coord);
     }
 
-    #[inline(always)]
     pub fn is_captured(&self) -> bool {
         self.libs.len() == 0
     }

--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -72,12 +72,10 @@ impl Coord {
             .collect()
     }
 
-    #[inline(always)]
     pub fn to_index(&self, board_size: u8) -> usize {
         (self.col as usize-1 + (self.row as usize-1)*board_size as usize)
     }
 
-    #[inline(always)]
     pub fn is_inside(&self, board_size: u8) -> bool {
         1 <= self.col && self.col <= board_size && 1 <= self.row && self.row <= board_size
     }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -74,7 +74,6 @@ pub enum Color {
 }
 
 impl Color {
-	#[inline(always)]
     pub fn opposite(&self) -> Color {
         match *self {
             White => Black,
@@ -180,11 +179,10 @@ impl Board {
         }
     }
 
-    #[inline(always)]
     pub fn neighbours(&self, c: Coord) -> &Vec<Coord> {
         &self.cache.neighbours[c.to_index(self.size)]
     }
-    #[inline(always)]
+
     pub fn diagonals(&self, c: Coord) -> &Vec<Coord> {
         &self.cache.diagonals[c.to_index(self.size)]
     }
@@ -196,15 +194,15 @@ impl Board {
     pub fn vacant(&self) -> &Vec<Coord> {
         &self.vacant
     }
-    #[inline(always)]
+
     pub fn color(&self, c: &Coord) -> Color {
         self.board[c.to_index(self.size)].color
     }
-    #[inline(always)]
+
     pub fn chain_id(&self, c: &Coord) -> usize {
         self.board[c.to_index(self.size)].chain_id
     }
-    #[inline(always)]
+
     pub fn get_chain<'b>(&'b self, c: Coord) -> Option<&'b Chain> {
         let ref point = self.board[c.to_index(self.size)];
         if point.color != Empty {
@@ -225,7 +223,7 @@ impl Board {
     pub fn next_player(&self) -> Color {
         self.previous_player.opposite()
     }
-    //#[inline(never)] //turn off for profiling
+
     pub fn is_eye(&self, coord: &Coord, color: Color) -> bool {
         let neighbours = self.neighbours(*coord);
         if neighbours.iter().all(|c| self.color(c) == color) {
@@ -239,7 +237,7 @@ impl Board {
             false
         }
     }
-    #[inline(always)]
+
     fn is_same_player(&self, m: &Move) -> bool {
         self.previous_player == *m.color()
     }
@@ -251,7 +249,7 @@ impl Board {
     pub fn friend_stones_removed(&self) -> &Vec<Coord> {
         &self.friend_stones_removed
     }
-    //#[inline(never)] //turn off for profiling
+
     pub fn legal_moves_without_superko_check(&self) -> Vec<Move> {
         if self.is_game_over() {
             vec!()
@@ -265,14 +263,13 @@ impl Board {
         }
     }
 
-    //#[inline(never)] //turn off for profiling
     pub fn legal_moves_without_eyes(&self) -> Vec<Move> {
         self.legal_moves_without_superko_check()
             .into_iter()
             .filter(|m| m.is_pass() || !self.is_eye(&m.coord(), *m.color()))
             .collect()
     }
-    //#[inline(never)] //turn off for profiling
+
     pub fn is_legal(&self, m: Move) -> Result<(), IllegalMove> {
         // Can't play if the game is already over
         if self.is_game_over() && !self.ruleset.game_over_play() {
@@ -331,7 +328,7 @@ impl Board {
         }
         Ok(())
     }
-    //#[inline(never)] //turn off for profiling
+
     // Note: Same as get(), the board is indexed starting at 1-1
     pub fn play(&mut self, m: Move) -> Result<(), IllegalMove> {
         try!(self.is_legal(m));
@@ -379,15 +376,13 @@ impl Board {
         self.update_vacant(&m);
     }
 
-
-    //#[inline(never)] //turn off for profiling
     fn update_vacant(&mut self, m: &Move) {
         let pos = self.vacant.iter().position(|&c| c == m.coord()).unwrap();
         self.vacant.swap_remove(pos);
         self.vacant.push_all(self.adv_stones_removed.as_ref());
         self.vacant.push_all(self.friend_stones_removed.as_ref());
     }
-    //#[inline(never)] //turn off for profiling
+
     fn add_removed_adv_stones_as_libs(&mut self, m: &Move) {
         let color = *m.color();
         let mut libs: HashMap<Coord, Vec<usize>> = HashMap::new();
@@ -405,7 +400,7 @@ impl Board {
             }
         }
     }
-    //#[inline(never)] //turn off for profiling
+
     fn add_removed_friendly_stones_as_libs(&mut self, m: &Move) {
         let color = m.color().opposite();
         let mut libs: HashMap<Coord, Vec<usize>> = HashMap::new();
@@ -423,7 +418,7 @@ impl Board {
             }
         }
     }
-    //#[inline(never)] //turn off for profiling
+
     fn update_libs_of_adjacent_opposing_chains(&mut self, m: &Move) {
         let coord = m.coord();
         let color = m.color().opposite();
@@ -436,7 +431,7 @@ impl Board {
             self.chains[id].remove_liberty(coord);
         }
     }
-    //#[inline(never)] //turn off for profiling
+
     fn find_neighbouring_friendly_chains_ids(&self, m: &Move) -> Vec<usize> {
         let mut friend_neigh_chains_id: Vec<usize> = self.neighbours(m.coord())
             .iter()
@@ -452,7 +447,7 @@ impl Board {
         friend_neigh_chains_id.dedup();
         friend_neigh_chains_id
     }
-    //#[inline(never)] //turn off for profiling
+
     fn merge_or_create_chain(&mut self, m: &Move) {
         let mut chain_ids = self.find_neighbouring_friendly_chains_ids(m);
         let new_chain_id = self.create_new_chain(m);
@@ -478,7 +473,7 @@ impl Board {
         // Removes the played stone from the liberty
         self.chains[final_chain_id].remove_liberty(m.coord());
     }
-    //#[inline(never)] //turn off for profiling
+
     fn update_board_ids_after_id(&mut self, id: usize) {
         for i in id..self.chains.len() {
             for &coord in self.chains[i].coords().iter() {
@@ -486,18 +481,18 @@ impl Board {
             }
         }
     }
-    //#[inline(never)] //turn off for profiling
+
     fn update_chains_ids_after_id(&mut self, removed_chain_id: usize) {
         for i in removed_chain_id..self.chains.len() {
             self.chains[i].set_id(i);
         }
     }
-    //#[inline(never)] //turn off for profiling
+
     fn update_all_after_id(&mut self, id: usize) {
         self.update_board_ids_after_id(id);
         self.update_chains_ids_after_id(id);
     }
-    //#[inline(never)] //turn off for profiling
+
     fn remove_captured_opponent_stones(&mut self, m: &Move) -> Vec<Coord> {
         let coord = m.coord();
         let color = m.color().opposite();
@@ -525,14 +520,14 @@ impl Board {
         }
         coords_to_remove
     }
-    //#[inline(never)] //turn off for profiling
+
     fn remove_suicide_chain(&mut self, m: &Move) -> Vec<Coord> {
         let coords_to_remove = self.get_chain(m.coord()).unwrap().coords().clone();
         let chain_id = self.chain_id(&m.coord());
         self.remove_chain(chain_id);
         coords_to_remove
     }
-    //#[inline(never)] //turn off for profiling
+
     fn remove_chain(&mut self, id: usize) {
         let coords_to_remove = self.chains[id].coords().clone();
 
@@ -543,7 +538,7 @@ impl Board {
         self.chains.remove(id);
         self.update_all_after_id(id);
     }
-    //#[inline(never)] //turn off for profiling
+
     fn create_new_chain(&mut self, m: &Move) -> usize {
         let new_chain_id = self.chains.len();
         let new_chain    = Chain::new(
@@ -553,11 +548,11 @@ impl Board {
         self.board[m.coord().to_index(self.size)].color = *m.color();
         new_chain_id
     }
-    //#[inline(never)] //turn off for profiling
+
     fn liberties(&self, c: &Coord) -> HashSet<Coord> {
         self.neighbours(*c).iter().filter(|&c| self.color(c) == Empty).cloned().collect()
     }
-    #[inline(always)]
+
     fn remove_stone(&mut self, c: Coord) {
         // Resetting the chain_id is not strictly necessary, but will
         // make debugging easier.
@@ -577,7 +572,6 @@ impl Board {
         }
     }
 
-    #[inline(always)]
     pub fn is_game_over(&self) -> bool {
         self.consecutive_passes == 2 || self.resigned_by != Empty
     }

--- a/src/board/movement/mod.rs
+++ b/src/board/movement/mod.rs
@@ -60,7 +60,6 @@ impl Move {
         }
     }
 
-    #[inline(always)]
     pub fn color(&self) -> &Color {
         match *self {
             Play(ref c, _, _) => c,
@@ -70,7 +69,6 @@ impl Move {
         }
     }
 
-    #[inline(always)]
     pub fn coord(&self) -> Coord {
         match *self {
             Play(_, col, row) => Coord::new(col, row),
@@ -80,7 +78,6 @@ impl Move {
         }
     }
 
-    #[inline(always)]
     pub fn is_pass(&self) -> bool {
         match *self {
             Pass(_) => true,


### PR DESCRIPTION
I ran the benchmarks with and without the inline hints, and there's virtually no speed difference. If at all it's the other way round. Without the inline hints the `NoSelfAtariPlayouts` are now as fast as the light playouts.