### PR TITLE
Add priors to the UCT search

### DIFF
--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -80,6 +80,13 @@ impl Coord {
         1 <= self.col && self.col <= board_size && 1 <= self.row && self.row <= board_size
     }
 
+    pub fn distance_to_border(&self, board_size: u8) -> u8 {
+        *vec!(self.col-1, self.row-1, board_size - self.col, board_size - self.row)
+            .iter()
+            .min()
+            .unwrap()
+    }
+
     // Note: there is no I column.
     pub fn from_gtp(gtp_vertex: &str) -> Coord {
         let col_letter = gtp_vertex.chars().next().unwrap().to_lowercase().next().unwrap();

--- a/src/board/coord/mod.rs
+++ b/src/board/coord/mod.rs
@@ -87,6 +87,26 @@ impl Coord {
             .unwrap()
     }
 
+    pub fn manhattan_distance_three_neighbours(&self, board_size: u8) -> Vec<Coord> {
+        let offsets = vec!(
+                                      (0, 3),
+                             (-1, 2), (0, 2), (1, 2),
+                    (-2, 1), (-1, 1), (0, 1), (1, 1), (2, 1),
+            (-3,0), (-2, 0), (-1, 0),         (1, 0), (2, 0), (3,0),
+                    (-2,-1), (-1,-1), (0,-1), (1,-1), (2,-1),
+                             (-1,-2), (0,-2), (1,-2),
+                                      (0,-3)
+                );
+        let calc: Vec<(isize, isize)> = offsets.iter()
+            .map(|&(co,ro)| (self.col as isize + co, self.row as isize + ro))
+            .filter(|&(co,ro)| co > 0 && ro > 0)
+            .collect();
+        calc.iter()
+            .map(|&(c,r)| Coord::new(c as u8,r as u8))
+            .filter(|c| c.is_inside(board_size))
+            .collect()
+    }
+
     // Note: there is no I column.
     pub fn from_gtp(gtp_vertex: &str) -> Coord {
         let col_letter = gtp_vertex.chars().next().unwrap().to_lowercase().next().unwrap();

--- a/src/board/coord/test.rs
+++ b/src/board/coord/test.rs
@@ -104,3 +104,13 @@ fn for_board_size_sets_the_coordinates_correctly() {
     let coords = Coord::for_board_size(1);
     assert_eq!(coords[0], Coord::new(1,1));
 }
+
+#[test]
+fn distance_to_border() {
+    let size = 9;
+    assert_eq!(0, Coord::new(1,5).distance_to_border(size));
+    assert_eq!(0, Coord::new(5,1).distance_to_border(size));
+    assert_eq!(0, Coord::new(9,5).distance_to_border(size));
+    assert_eq!(0, Coord::new(5,9).distance_to_border(size));
+    assert_eq!(1, Coord::new(2,5).distance_to_border(size));
+}

--- a/src/board/coord/test.rs
+++ b/src/board/coord/test.rs
@@ -114,3 +114,17 @@ fn distance_to_border() {
     assert_eq!(0, Coord::new(5,9).distance_to_border(size));
     assert_eq!(1, Coord::new(2,5).distance_to_border(size));
 }
+
+#[test]
+fn manhattan_distance_three_neighbours_middle_of_board() {
+    let coord = Coord::new(5, 5);
+    let size = 9;
+    assert_eq!(24, coord.manhattan_distance_three_neighbours(size).len());
+}
+
+#[test]
+fn manhattan_distance_three_neighbours_in_a_corner() {
+    let coord = Coord::new(1, 1);
+    let size = 9;
+    assert_eq!(9, coord.manhattan_distance_three_neighbours(size).len());
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ pub struct UctPriorsConfig {
     pub capture_many: usize,
     pub neutral_plays: usize,
     pub neutral_wins: usize,
+    pub self_atari: usize,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -84,6 +85,7 @@ impl Config {
                     capture_many: 30,
                     neutral_plays: 10,
                     neutral_wins: 5,
+                    self_atari: 10,
                 },
                 reuse_subtree: true,
                 tuned: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,8 +33,9 @@ pub struct UctConfig {
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctPriorsConfig {
-    pub capture_one: usize,
     pub capture_many: usize,
+    pub capture_one: usize,
+    pub empty: usize,
     pub neutral_plays: usize,
     pub neutral_wins: usize,
     pub self_atari: usize,
@@ -81,8 +82,9 @@ impl Config {
                 end_of_game_cutoff: 0.01,
                 expand_after: 1,
                 priors: UctPriorsConfig {
-                    capture_one: 15,
                     capture_many: 30,
+                    capture_one: 15,
+                    empty: 10,
                     neutral_plays: 10,
                     neutral_wins: 5,
                     self_atari: 10,

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,26 +22,33 @@
 use ruleset::Minimal;
 use ruleset::Ruleset;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctConfig {
     pub end_of_game_cutoff: f32,
     pub expand_after: usize,
+    pub priors: UctPriorsConfig,
     pub reuse_subtree: bool,
     pub tuned: bool,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct UctPriorsConfig {
+    pub neutral_plays: usize,
+    pub neutral_wins: usize,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TimerConfig {
     pub c: f32,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PlayoutConfig {
     pub ladder_check: bool,
     pub no_self_atari_cutoff: usize,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Config {
     pub debug: bool,
     pub log: bool,
@@ -70,6 +77,10 @@ impl Config {
             uct: UctConfig {
                 end_of_game_cutoff: 0.01,
                 expand_after: 1,
+                priors: UctPriorsConfig {
+                    neutral_plays: 10,
+                    neutral_wins: 5,
+                },
                 reuse_subtree: true,
                 tuned: true,
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct UctConfig {
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctPriorsConfig {
+    pub capture_one: usize,
+    pub capture_many: usize,
     pub neutral_plays: usize,
     pub neutral_wins: usize,
 }
@@ -78,6 +80,8 @@ impl Config {
                 end_of_game_cutoff: 0.01,
                 expand_after: 1,
                 priors: UctPriorsConfig {
+                    capture_one: 15,
+                    capture_many: 30,
                     neutral_plays: 10,
                     neutral_wins: 5,
                 },

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -25,6 +25,7 @@ use board::Black;
 use board::Pass;
 use board::Play;
 use board::White;
+use config::Config;
 use game::Game;
 use ruleset::KgsChinese;
 use sgf::Parser;
@@ -35,7 +36,7 @@ use std::path::Path;
 #[test]
 fn root_expands_the_children() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let root = Node::root(&game, Black);
+    let root = Node::root(&game, Black, Config::default());
     assert_eq!(4, root.children.len());
 }
 
@@ -44,45 +45,35 @@ fn expand_doesnt_add_children_to_terminal_nodes() {
     let mut game = Game::new(5, 6.5, KgsChinese);
     game = game.play(Pass(Black)).unwrap();
     game = game.play(Pass(White)).unwrap();
-    let mut node = Node::new(Pass(Black));
-    node.expand(&game.board(), 1);
+    let mut node = Node::new(Pass(Black), Config::default());
+    node.expand(&game.board());
     assert_eq!(0, node.children.len());
 }
 
 #[test]
 fn expand_doesnt_add_children_if_threshold_not_met() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let mut node = Node::new(Pass(Black));
-    node.expand(&game.board(), 2);
+    let mut node = Node::new(Pass(Black), Config::default());
+    node.plays = 0;
+    node.expand(&game.board());
     assert_eq!(0, node.children.len());
 }
 
 #[test]
 fn expand_adds_children_if_threshold_is_met() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let mut node = Node::new(Pass(Black));
+    let mut node = Node::new(Pass(Black), Config::default());
     node.plays = 2;
-    node.expand(&game.board(), 2);
+    node.expand(&game.board());
     assert_eq!(4, node.children.len());
-}
-
-#[test]
-fn unvisited_children_are_explored_first() {
-    let game = Game::new(2, 0.5, KgsChinese);
-    let mut root = Node::root(&game, Black);
-    for _ in 0..4 {
-        root.find_leaf_and_expand(&game, 1, false);
-    }
-    assert_eq!(4, root.children.len());
-    assert!(root.children.iter().all(|n| n.plays == 1));
 }
 
 #[test]
 fn find_leaf_and_expand_expands_the_leaves() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let mut root = Node::root(&game, Black);
+    let mut root = Node::root(&game, Black, Config::default());
     for _ in 0..4 {
-        root.find_leaf_and_expand(&game, 1, false);
+        root.find_leaf_and_expand(&game);
     }
     assert_eq!(4, root.children.len());
     assert!(root.children.iter().all(|n| n.children.len() == 3));
@@ -91,23 +82,23 @@ fn find_leaf_and_expand_expands_the_leaves() {
 #[test]
 fn find_leaf_and_expand_sets_play_on_the_root() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let mut root = Node::root(&game, Black);
-    root.find_leaf_and_expand(&game, 1, false);
+    let mut root = Node::root(&game, Black, Config::default());
+    root.find_leaf_and_expand(&game);
     assert_eq!(2, root.plays);
 }
 
 #[test]
 fn find_leaf_and_expand_returns_the_number_of_nodes_added() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let mut root = Node::root(&game, Black);
-    let (_,_,_,count) = root.find_leaf_and_expand(&game, 1, false);
+    let mut root = Node::root(&game, Black, Config::default());
+    let (_,_,_,count) = root.find_leaf_and_expand(&game);
     assert_eq!(3, count);
 }
 
 #[test]
 fn the_root_needs_to_be_initialized_with_1_plays_for_correct_uct_calculations() {
     let game = Game::new(2, 0.5, KgsChinese);
-    let root = Node::root(&game, Black);
+    let root = Node::root(&game, Black, Config::default());
     assert_eq!(1, root.plays);
     assert_eq!(1, root.wins);
  }
@@ -116,39 +107,40 @@ fn the_root_needs_to_be_initialized_with_1_plays_for_correct_uct_calculations() 
 fn no_super_ko_violations_in_the_children_of_the_root() {
     let parser = Parser::from_path(Path::new("fixtures/sgf/positional-superko.sgf")).unwrap();
     let game = parser.game().unwrap();
-    let root = Node::root(&game, White);
+    let root = Node::root(&game, White, Config::default());
     // Play(White, 2, 9) is a super ko violation
     assert!(root.children.iter().all(|n| n.m() != Play(White, 2, 9)));
 }
 
 #[test]
 fn record_on_path_only_records_wins_for_the_correct_color() {
-    let grandchild = Node::new(Pass(Black));
-    let mut child = Node::new(Pass(White));
+    let config = Config::default();
+    let grandchild = Node::new(Pass(Black), config);
+    let mut child = Node::new(Pass(White), config);
     child.children = vec!(grandchild);
-    let mut root = Node::new(Pass(Black));
+    let mut root = Node::new(Pass(Black), config);
     root.children = vec!(child);
 
     root.record_on_path(&vec!(0, 0), Black, 0);
-    assert_eq!(1, root.wins);
-    assert_eq!(0, root.children[0].wins);
-    assert_eq!(1, root.children[0].children[0].wins);
+    assert_eq!(6, root.wins);
+    assert_eq!(5, root.children[0].wins);
+    assert_eq!(6, root.children[0].children[0].wins);
 
     root.record_on_path(&vec!(0, 0), White, 0);
-    assert_eq!(1, root.wins);
-    assert_eq!(1, root.children[0].wins);
-    assert_eq!(1, root.children[0].children[0].wins);
+    assert_eq!(6, root.wins);
+    assert_eq!(6, root.children[0].wins);
+    assert_eq!(6, root.children[0].children[0].wins);
 }
 
 #[test]
 fn record_on_path_updates_the_descendant_counts() {
-    let mut grandchild = Node::new(Pass(Black));
+    let mut grandchild = Node::new(Pass(Black), Config::default());
     // The leaf already has the correct value set
     grandchild.descendants = 5;
-    let mut child = Node::new(Pass(White));
+    let mut child = Node::new(Pass(White), Config::default());
     child.children = vec!(grandchild);
     child.descendants = 1;
-    let mut root = Node::new(Pass(Black));
+    let mut root = Node::new(Pass(Black), Config::default());
     root.children = vec!(child);
     root.descendants = 2;
 
@@ -160,22 +152,22 @@ fn record_on_path_updates_the_descendant_counts() {
 
 #[test]
 fn find_child_returns_the_correct_child() {
-    let mut root = Node::new(Pass(Black));
-    let child = Node::new(Play(White, 1, 1));
-    root.children = vec!(Node::new(Play(Black, 5, 5)), child.clone(), Node::new(Play(Black, 3, 7)));
+    let mut root = Node::new(Pass(Black), Config::default());
+    let child = Node::new(Play(White, 1, 1), Config::default());
+    root.children = vec!(Node::new(Play(Black, 5, 5), Config::default()), child.clone(), Node::new(Play(Black, 3, 7), Config::default()));
     assert_eq!(child, root.find_child(Play(White, 1, 1)));
 }
 
 #[test]
 fn new_sets_the_descendats_to_zero() {
-    let node = Node::new(Pass(Black));
+    let node = Node::new(Pass(Black), Config::default());
     assert_eq!(0, node.descendants);
 }
 
 #[test]
 fn expand_root_sets_the_correct_descendant_count_on_the_root() {
     let game = Game::new(5, 6.5, KgsChinese);
-    let mut root = Node::new(Pass(Black));
+    let mut root = Node::new(Pass(Black), Config::default());
     root.expand_root(&game);
     assert_eq!(25, root.descendants);
 }
@@ -184,8 +176,8 @@ fn expand_root_sets_the_correct_descendant_count_on_the_root() {
 fn expand_sets_the_descendant_count_if_the_node_was_expanded() {
     let game = Game::new(5, 6.5, KgsChinese);
     let board = game.board();
-    let mut node = Node::new(Pass(Black));
-    node.expand(&board, 0);
+    let mut node = Node::new(Pass(Black), Config::default());
+    node.expand(&board);
     assert_eq!(25, node.descendants);
 }
 


### PR DESCRIPTION
This is not ready for merging, but I wanted to record my statistics before I move on: Iomrascálaí won 44.2% (+/- 5.4%) out of 86 games. That is around 10% better than before. This is with only two priors (stolen from Michi) and it's especially impressive as the slowdown is massive as the prior calculation happens serially in the main thread.

I'll add another prior from Michi (concerning empty areas on the board) and then I guess we should merge it.