### PR TITLE
Empty area prior config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct UctPriorsConfig {
     pub neutral_plays: usize,
     pub neutral_wins: usize,
     pub self_atari: usize,
+    pub use_empty: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -88,6 +89,7 @@ impl Config {
                     neutral_plays: 10,
                     neutral_wins: 5,
                     self_atari: 10,
+                    use_empty: false,
                 },
                 reuse_subtree: true,
                 tuned: true,

--- a/src/engine/uct/node/mod.rs
+++ b/src/engine/uct/node/mod.rs
@@ -178,14 +178,16 @@ impl Node {
             node.plays += self.config.uct.priors.self_atari;
             node.wins += 0; // That's a negative prior
         }
-        let distance = m.coord().distance_to_border(board.size());
-        if distance <= 2 && self.in_empty_area(board, m) {
-            if distance <= 1 {
-                node.plays += self.config.uct.priors.empty;
-                node.wins += 0; // That's a negative prior
-            } else {
-                node.plays += self.config.uct.priors.empty;
-                node.wins += self.config.uct.priors.empty;
+        if self.config.uct.priors.use_empty {
+            let distance = m.coord().distance_to_border(board.size());
+            if distance <= 2 && self.in_empty_area(board, m) {
+                if distance <= 1 {
+                    node.plays += self.config.uct.priors.empty;
+                    node.wins += 0; // That's a negative prior
+                } else {
+                    node.plays += self.config.uct.priors.empty;
+                    node.wins += self.config.uct.priors.empty;
+                }
             }
         }
         node

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,9 @@ pub fn main() {
     opts.optflag("s", "simple", "faster playouts (no ladder reading)");
     opts.optflag("v", "version", "print the version number");
 
-    opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", config.uct.priors.use_empty).as_ref(), "true|false");
+    opts.optopt("", "empty-area-prior", format!("prior value for empty areas (defaults to {})", config.uct.priors.empty).as_ref(), "NUM");
     opts.optopt("", "reuse-subtree", "reuse the subtree from the previous search (defaults to true)", "true|false");
+    opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", config.uct.priors.use_empty).as_ref(), "true|false");
     opts.optopt("P", "policies", "choose which policy to use (defaults to tuned)", "tuned|ucb1");
     opts.optopt("e", "engine", "select an engine (defaults to uct)", "amaf|mc|random|uct");
     opts.optopt("p", "playout", "type of playout to use (defaults to no-self-atari)", "light|no-self-atari");
@@ -100,6 +101,17 @@ pub fn main() {
         println!("Iomrascálaí {}", version::version());
         return;
     }
+    if matches.opt_present("empty-area-prior") {
+        let arg = matches.opt_str("empty-area-prior").unwrap();
+        config.uct.priors.empty = match arg.parse::<usize>() {
+            Ok(v) => v,
+            Err(_) => {
+                println!("Unknown value ({}) as argument to --empty-area-prior", arg);
+                exit(1);
+            }
+        }
+    }
+
     if matches.opt_present("use-empty-area-prior") {
         let arg = matches.opt_str("use-empty-area-prior").map(|s| s.into_ascii_lowercase()).unwrap();
         config.uct.priors.use_empty = match arg.parse::<bool>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ use version::version;
 use getopts::Options;
 use std::ascii::OwnedAsciiExt;
 use std::env::args;
+use std::io::Write;
 use std::process::exit;
 
 macro_rules! log(
@@ -162,5 +163,8 @@ pub fn main() {
     let playout = playout::factory(matches.opt_str("p"), config);
     config.playout.ladder_check = matches.opt_present("s");
     let engine = engine::factory(matches.opt_str("e"), config, playout);
+
+    log!("Current configuration: {:?}", config);
+
     Driver::new(config, engine);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,10 @@ pub fn main() {
 
     let matches = match opts.parse(args.tail()) {
         Ok(m) => m,
-        Err(f) => panic!(f.to_string())
+        Err(f) => {
+            println!("{}", f.to_string());
+            exit(1);
+        }
     };
 
     if matches.opt_present("h") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ pub fn main() {
     }
     if matches.opt_present("empty-area-prior") {
         let arg = matches.opt_str("empty-area-prior").unwrap();
-        config.uct.priors.empty = match arg.parse::<usize>() {
+        config.uct.priors.empty = match arg.parse() {
             Ok(v) => v,
             Err(_) => {
                 println!("Unknown value ({}) as argument to --empty-area-prior", arg);
@@ -115,7 +115,7 @@ pub fn main() {
 
     if matches.opt_present("use-empty-area-prior") {
         let arg = matches.opt_str("use-empty-area-prior").map(|s| s.into_ascii_lowercase()).unwrap();
-        config.uct.priors.use_empty = match arg.parse::<bool>() {
+        config.uct.priors.use_empty = match arg.parse() {
             Ok(v) => v,
             Err(_) => {
                 println!("Unknown value ({}) as argument to --use-empty-area-prior", arg);
@@ -127,7 +127,7 @@ pub fn main() {
     let reuse_subtree_arg = matches.opt_str("reuse-subtree").map(|s| s.into_ascii_lowercase());
     let reuse_subtree = match reuse_subtree_arg {
         Some(arg) => {
-            match arg.parse::<bool>() {
+            match arg.parse() {
                 Ok(v) => v,
                 Err(_) => panic!("Unknown value ({}) as argument to --reuse-subtree", arg)
             }
@@ -138,7 +138,7 @@ pub fn main() {
 
     let threads = match matches.opt_str("t") {
         Some(s) => {
-            match s.parse::<usize>() {
+            match s.parse() {
                 Ok(n)  => n,
                 Err(_) => 1
             }


### PR DESCRIPTION
This adds a command line option to turn the empty area prior on and off as well as one to set the actual value of the prior. It also sets the default for the empty are prior to `false`, i.e. it's turned off by default. I'm currently running benchmarks that suggest that it is actually detrimental in it's current form. I'll know later today if it's due to the slowdown of the additional calculations or if the prior values themselves are a problem.

Also, have a look at how I'm setting these values and how I don't duplicate the default value in the `match` and instead I use the one set by `Config::default()`. Next I'll clean up the whole command line option stuff. It really doesn't need to live in `main()` and there's also a lot of duplication.