### PR TITLE
Rename the --simple command line flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ impl Config {
             debug: true,
             log: false,
             playout: PlayoutConfig {
-                ladder_check: true,
+                ladder_check: false,
                 no_self_atari_cutoff: 7,
             },
             ruleset: Minimal,


### PR DESCRIPTION
In `Config` the ladder check for the playouts had a default value of true. But that was never used as it was always overwritten in `main()`. Also when `--simple` was set, the ladder check was turned **on**.

I've now renamed it to `--use-ladder-check-in-playouts` and it now uses the default from `Config` (which I've changed to false so that the bot behaves the same as before).

Like I said before, this is a lot of boilerplate code and I'll move it out of `main()` eventually and maybe even write a macro or two to simplify it.