### PR TITLE
Refactor command line options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,6 @@ use version;
 
 use getopts::Matches;
 use getopts::Options;
-use std::ascii::OwnedAsciiExt;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctConfig {
@@ -150,20 +149,16 @@ impl Config {
         }
 
         opt!(matches, "empty-area-prior", self.uct.priors.empty);
+        opt!(matches, "r", "ruleset", self.ruleset);
+        opt!(matches, "reuse-subtree", self.uct.reuse_subtree);
+        opt!(matches, "t", "threads", self.threads);
         opt!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
         opt!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
         opt!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
-        opt!(matches, "reuse-subtree", self.uct.reuse_subtree);
-        opt!(matches, "t", "threads", self.threads);
-        opt!(matches, "r", "ruleset", self.ruleset);
+        opt!(matches, "use-ucb1-tuned", self.uct.tuned);
 
         flag!(matches, "l", "log", self.log);
 
-        let policy = matches.opt_str("P").map(|s| s.into_ascii_lowercase());
-        self.uct.tuned = match policy {
-            Some(str) => if str == "ucb1" { false } else { true},
-            _ => true
-        };
         Ok(None)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,7 @@ impl Config {
             log: false,
             playout: PlayoutConfig {
                 atari_check: true,
-                ladder_check: false,
+                ladder_check: true,
                 no_self_atari_cutoff: 7,
             },
             ruleset: KgsChinese,

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,18 +143,12 @@ impl Config {
         set_if_present!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
         set_if_present!(matches, "reuse-subtree", self.uct.reuse_subtree);
         set_if_present!(matches, "t", "threads", self.threads);
+        set_if_present!(matches, "r", "ruleset", self.ruleset);
 
         let log = matches.opt_present("l");
 
-        let rules_arg = matches.opt_str("r").map(|s| s.into_ascii_lowercase());
-        let ruleset = match rules_arg {
-            Some(r) => Ruleset::from_string(r),
-            None    => KgsChinese
-        };
-
         let policy = matches.opt_str("P").map(|s| s.into_ascii_lowercase());
         self.log = log;
-        self.ruleset = ruleset;
         self.uct.tuned = match policy {
             Some(str) => if str == "ucb1" { false } else { true},
             _ => true

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,16 +72,7 @@ pub struct Config {
 
 macro_rules! set_if_present {
     ($matches:expr, $longopt:expr, $key:expr) => {
-        if $matches.opt_present($longopt) {
-            let arg = $matches.opt_str($longopt).unwrap();
-            $key = match arg.parse() {
-                Ok(v) => v,
-                Err(_) => {
-                    let s = format!("Unknown value ({}) as argument to --{}", arg, $longopt);
-                    return Err(s);
-                }
-            }
-        }
+        set_if_present!($matches, "", $longopt, $key);
     };
     ($matches:expr, $shortopt:expr, $longopt:expr, $key:expr) => {
         if $matches.opt_present($longopt) {
@@ -89,7 +80,11 @@ macro_rules! set_if_present {
             $key = match arg.parse() {
                 Ok(v) => v,
                 Err(_) => {
-                    let s = format!("Unknown value ({}) as argument to --{} or -{}", arg, $longopt, $shortopt);
+                    let strs: Vec<String> = [format!("--{}", $longopt), format!("-{}", $shortopt)].iter()
+                        .filter(|&s| s != "")
+                        .cloned()
+                        .collect();
+                    let s = format!("Unknown value ({}) as argument to {}", arg, strs.connect(" or "));
                     return Err(s);
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,10 @@
 
 use ruleset::KgsChinese;
 use ruleset::Ruleset;
+use version;
 
 use getopts::Matches;
+use getopts::Options;
 use std::ascii::OwnedAsciiExt;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -117,7 +119,17 @@ impl Config {
         }
     }
 
-    pub fn set_from_opts(&mut self, matches: &Matches) -> Result<(), String>{
+    pub fn set_from_opts(&mut self, matches: &Matches, opts: &Options, args: &Vec<String>) -> Result<Option<String>, String>{
+        if matches.opt_present("h") {
+            let brief = format!("Usage: {} [options]", args[0]);
+            let s = format!("{}", opts.usage(brief.as_ref()));
+            return Ok(Some(s));
+        }
+        if matches.opt_present("v") {
+            let s = format!("Iomrascálaí {}", version::version());
+            return Ok(Some(s));
+        }
+
         set_if_present!(matches, "empty-area-prior", self.uct.priors.empty);
         set_if_present!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
         set_if_present!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
@@ -148,7 +160,7 @@ impl Config {
             Some(str) => if str == "ucb1" { false } else { true},
             _ => true
         };
-        Ok(())
+        Ok(None)
     }
 
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ use ruleset::Ruleset;
 
 use getopts::Matches;
 use std::ascii::OwnedAsciiExt;
-use std::process::exit;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctConfig {
@@ -76,8 +75,8 @@ macro_rules! set_if_present {
             $key = match arg.parse() {
                 Ok(v) => v,
                 Err(_) => {
-                    println!("Unknown value ({}) as argument to --{}", arg, $opt);
-                    exit(1);
+                    let s = format!("Unknown value ({}) as argument to --{}", arg, $opt);
+                    return Err(s);
                 }
             }
         }
@@ -118,7 +117,7 @@ impl Config {
         }
     }
 
-    pub fn set_from_opts(&mut self, matches: &Matches) {
+    pub fn set_from_opts(&mut self, matches: &Matches) -> Result<(), String>{
         set_if_present!(matches, "empty-area-prior", self.uct.priors.empty);
         set_if_present!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
         set_if_present!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
@@ -149,6 +148,7 @@ impl Config {
             Some(str) => if str == "ucb1" { false } else { true},
             _ => true
         };
+        Ok(())
     }
 
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,9 +70,9 @@ pub struct Config {
     pub uct: UctConfig,
 }
 
-macro_rules! set_if_present {
+macro_rules! opt {
     ($matches:expr, $longopt:expr, $key:expr) => {
-        set_if_present!($matches, "", $longopt, $key);
+        opt!($matches, "", $longopt, $key);
     };
     ($matches:expr, $shortopt:expr, $longopt:expr, $key:expr) => {
         if $matches.opt_present($longopt) {
@@ -137,13 +137,13 @@ impl Config {
             return Ok(Some(s));
         }
 
-        set_if_present!(matches, "empty-area-prior", self.uct.priors.empty);
-        set_if_present!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
-        set_if_present!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
-        set_if_present!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
-        set_if_present!(matches, "reuse-subtree", self.uct.reuse_subtree);
-        set_if_present!(matches, "t", "threads", self.threads);
-        set_if_present!(matches, "r", "ruleset", self.ruleset);
+        opt!(matches, "empty-area-prior", self.uct.priors.empty);
+        opt!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
+        opt!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
+        opt!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
+        opt!(matches, "reuse-subtree", self.uct.reuse_subtree);
+        opt!(matches, "t", "threads", self.threads);
+        opt!(matches, "r", "ruleset", self.ruleset);
 
         let log = matches.opt_present("l");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@
  ************************************************************************/
 
 use ruleset::KgsChinese;
-use ruleset::Minimal;
 use ruleset::Ruleset;
 
 use getopts::Matches;
@@ -96,7 +95,7 @@ impl Config {
                 ladder_check: false,
                 no_self_atari_cutoff: 7,
             },
-            ruleset: Minimal,
+            ruleset: KgsChinese,
             threads: 1,
             timer: TimerConfig {
                 c: 0.5

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,18 @@ macro_rules! opt {
     };
 }
 
+macro_rules! flag {
+    ($matches:expr, $longopt:expr, $key:expr) => {
+        flag!($matches, "", $longopt, $key);
+    };
+    ($matches:expr, $shortopt:expr, $longopt:expr, $key:expr) => {
+        // Do it with an if so as to not override the default
+        if $matches.opt_present($longopt) {
+            $key = true;
+        }
+    };
+}
+
 impl Config {
 
     pub fn default() -> Config {
@@ -145,10 +157,9 @@ impl Config {
         opt!(matches, "t", "threads", self.threads);
         opt!(matches, "r", "ruleset", self.ruleset);
 
-        let log = matches.opt_present("l");
+        flag!(matches, "l", "log", self.log);
 
         let policy = matches.opt_str("P").map(|s| s.into_ascii_lowercase());
-        self.log = log;
         self.uct.tuned = match policy {
             Some(str) => if str == "ucb1" { false } else { true},
             _ => true

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,21 @@ pub struct Config {
     pub uct: UctConfig,
 }
 
+macro_rules! set_if_present {
+    ($matches:expr, $opt:expr, $key:expr) => {
+        if $matches.opt_present($opt) {
+            let arg = $matches.opt_str($opt).unwrap();
+            $key = match arg.parse() {
+                Ok(v) => v,
+                Err(_) => {
+                    println!("Unknown value ({}) as argument to --{}", arg, $opt);
+                    exit(1);
+                }
+            }
+        }
+    }
+}
+
 impl Config {
 
     pub fn default() -> Config {
@@ -105,60 +120,11 @@ impl Config {
     }
 
     pub fn set_from_opts(&mut self, matches: &Matches) {
-        if matches.opt_present("empty-area-prior") {
-            let arg = matches.opt_str("empty-area-prior").unwrap();
-            self.uct.priors.empty = match arg.parse() {
-                Ok(v) => v,
-                Err(_) => {
-                    println!("Unknown value ({}) as argument to --empty-area-prior", arg);
-                    exit(1);
-                }
-            }
-        }
-
-        if matches.opt_present("use-atari-check-in-playouts") {
-            let arg = matches.opt_str("use-atari-check-in-playouts").map(|s| s.into_ascii_lowercase()).unwrap();
-            config.playout.atari_check = match arg.parse() {
-                Ok(v) => v,
-                Err(_) => {
-                    println!("Unknown value ({}) as argument to --use-atari-check-in-playouts", arg);
-                    exit(1);
-                }
-            }
-        }
-
-        if matches.opt_present("use-empty-area-prior") {
-            let arg = matches.opt_str("use-empty-area-prior").map(|s| s.into_ascii_lowercase()).unwrap();
-            self.uct.priors.use_empty = match arg.parse() {
-                Ok(v) => v,
-                Err(_) => {
-                    println!("Unknown value ({}) as argument to --use-empty-area-prior", arg);
-                    exit(1);
-                }
-            }
-        }
-
-        if matches.opt_present("use-ladder-check-in-playouts") {
-            let arg = matches.opt_str("use-ladder-check-in-playouts").map(|s| s.into_ascii_lowercase()).unwrap();
-            self.playout.ladder_check = match arg.parse() {
-                Ok(v) => v,
-                Err(_) => {
-                    println!("Unknown value ({}) as argument to --use-ladder-check-in-playouts", arg);
-                    exit(1);
-                }
-            }
-        }
-
-        let reuse_subtree_arg = matches.opt_str("reuse-subtree").map(|s| s.into_ascii_lowercase());
-        let reuse_subtree = match reuse_subtree_arg {
-            Some(arg) => {
-                match arg.parse() {
-                    Ok(v) => v,
-                    Err(_) => panic!("Unknown value ({}) as argument to --reuse-subtree", arg)
-                }
-            },
-            None => true
-        };
+        set_if_present!(matches, "empty-area-prior", self.uct.priors.empty);
+        set_if_present!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
+        set_if_present!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
+        set_if_present!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
+        set_if_present!(matches, "reuse-subtree", self.uct.reuse_subtree);
         let log = matches.opt_present("l");
 
         let threads = match matches.opt_str("t") {
@@ -184,7 +150,6 @@ impl Config {
             Some(str) => if str == "ucb1" { false } else { true},
             _ => true
         };
-        self.uct.reuse_subtree = reuse_subtree;
     }
 
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,8 @@ use version;
 use getopts::Matches;
 use getopts::Options;
 
+mod test;
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UctConfig {
     pub end_of_game_cutoff: f32,
@@ -159,7 +161,15 @@ impl Config {
 
         flag!(matches, "l", "log", self.log);
 
-        Ok(None)
+        self.check()
     }
 
+    fn check(&self) -> Result<Option<String>, String> {
+        if self.playout.ladder_check && !self.playout.atari_check {
+            let s = String::from_str("'--use-ladder-check-in-playouts true' requires '--use-atari-check-in-playouts true'");
+            Err(s)
+        } else {
+            Ok(None)
+        }
+    }
 }

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -1,0 +1,32 @@
+/************************************************************************
+ *                                                                      *
+ * Copyright 2015 Urban Hafner                                          *
+ *                                                                      *
+ * This file is part of Iomrascálaí.                                    *
+ *                                                                      *
+ * Iomrascálaí is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by *
+ * the Free Software Foundation, either version 3 of the License, or    *
+ * (at your option) any later version.                                  *
+ *                                                                      *
+ * Iomrascálaí is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ * GNU General Public License for more details.                         *
+ *                                                                      *
+ * You should have received a copy of the GNU General Public License    *
+ * along with Iomrascálaí.  If not, see <http://www.gnu.org/licenses/>. *
+ *                                                                      *
+ ************************************************************************/
+
+#![cfg(test)]
+
+use super::Config;
+
+#[test]
+fn fail_if_ladder_and_atari_are_in_conflict() {
+    let mut config = Config::default();
+    config.playout.atari_check = false;
+    config.playout.ladder_check = true;
+    assert!(config.check().is_err());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ pub fn main() {
     opts.optopt("", "use-atari-check-in-playouts", format!("Check for atari in the playouts (defaults to {}", config.playout.ladder_check).as_ref(), "true|false");
     opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", config.uct.priors.use_empty).as_ref(), "true|false");
     opts.optopt("", "use-ladder-check-in-playouts", format!("Check for ladders in the playouts (defaults to {}", config.playout.ladder_check).as_ref(), "true|false");
-    opts.optopt("P", "policies", "choose which policy to use (defaults to tuned)", "tuned|ucb1");
+    opts.optopt("", "use-ucb1-tuned", format!("Use the UCB1tuned selection strategy (defaults to {})", config.uct.tuned).as_ref(), "true|false");
     opts.optopt("e", "engine", "select an engine (defaults to uct)", "amaf|mc|random|uct");
     opts.optopt("p", "playout", "type of playout to use (defaults to no-self-atari)", "light|no-self-atari");
     opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ extern crate time;
 
 use config::Config;
 use gtp::driver::Driver;
-use version::version;
 
 use getopts::Options;
 use std::env::args;
@@ -95,18 +94,17 @@ pub fn main() {
             exit(1);
         }
     };
-    if matches.opt_present("h") {
-        let brief = format!("Usage: {} [options]", args[0]);
-        print!("{}", opts.usage(brief.as_ref()));
-        return;
-    }
-    if matches.opt_present("v") {
-        println!("Iomrascálaí {}", version::version());
-        return;
-    }
 
-    match config.set_from_opts(&matches) {
-        Ok(_) => {},
+    match config.set_from_opts(&matches, &opts, &args) {
+        Ok(opt) => {
+            match opt {
+                Some(s) => {
+                    println!("{}", s);
+                    exit(0);
+                }
+                None => {}
+            }
+        },
         Err(s) => {
             println!("{}", s);
             exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,14 @@ pub fn main() {
         return;
     }
 
-    config.set_from_opts(&matches);
+    match config.set_from_opts(&matches) {
+        Ok(_) => {},
+        Err(s) => {
+            println!("{}", s);
+            exit(1);
+        }
+    }
+
     let playout = playout::factory(matches.opt_str("p"), config);
 
     let engine = engine::factory(matches.opt_str("e"), config, playout);

--- a/src/ruleset/mod.rs
+++ b/src/ruleset/mod.rs
@@ -25,6 +25,8 @@ pub use self::Ruleset::CGOS;
 pub use self::Ruleset::KgsChinese;
 pub use self::Ruleset::Minimal;
 
+use std::str::FromStr;
+
 mod test;
 
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
@@ -36,16 +38,6 @@ pub enum Ruleset {
 }
 
 impl Ruleset {
-
-    pub fn from_string(s: String) -> Ruleset {
-        match s.as_ref() {
-            "tromp-taylor" => AnySizeTrompTaylor,
-            "cgos"         => CGOS,
-            "chinese"      => KgsChinese,
-            "minimal"      => Minimal,
-            _              => panic!("Unknown ruleset '{}'", s),
-        }
-    }
 
     pub fn game_over_play(&self) -> bool {
         match *self {
@@ -68,4 +60,20 @@ impl Ruleset {
             _ => false
         }
     }
+}
+
+impl FromStr for Ruleset {
+
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Ruleset, Self::Err> {
+        match s {
+            "tromp-taylor" => Ok(AnySizeTrompTaylor),
+            "cgos"         => Ok(CGOS),
+            "chinese"      => Ok(KgsChinese),
+            "minimal"      => Ok(Minimal),
+            _              => Err(format!("Unknown ruleset '{}'", s)),
+        }
+    }
+
 }

--- a/src/ruleset/test/from_string.rs
+++ b/src/ruleset/test/from_string.rs
@@ -27,28 +27,29 @@ use ruleset::KgsChinese;
 use ruleset::Minimal;
 use ruleset::Ruleset;
 
+use std::str::FromStr;
+
 #[test]
 fn parses_tromp_taylor() {
-    assert_eq!(AnySizeTrompTaylor, Ruleset::from_string(String::from_str("tromp-taylor")));
+    assert_eq!(Ok(AnySizeTrompTaylor), Ruleset::from_str("tromp-taylor"));
 }
 
 #[test]
 fn parses_cgos() {
-    assert_eq!(CGOS, Ruleset::from_string(String::from_str("cgos")));
+    assert_eq!(Ok(CGOS), Ruleset::from_str("cgos"));
 }
 
 #[test]
 fn parses_chinese() {
-    assert_eq!(KgsChinese, Ruleset::from_string(String::from_str("chinese")));
+    assert_eq!(Ok(KgsChinese), Ruleset::from_str("chinese"));
 }
 
 #[test]
 fn parses_minimal() {
-    assert_eq!(Minimal, Ruleset::from_string(String::from_str("minimal")));
+    assert_eq!(Ok(Minimal), Ruleset::from_str("minimal"));
 }
 
 #[test]
-#[should_panic]
-fn fails_with_unknown() {
-    Ruleset::from_string(String::from_str("unknown"));
+fn errors_with_unknown() {
+    assert_eq!(Err(String::from_str("Unknown ruleset 'unknown'")), Ruleset::from_str("unknown"));
 }


### PR DESCRIPTION
A first refactoring of the command line code. It's still work in progress, but as we seem to add new options all the time it seems better to merge this now to avoid merging conflicts all the time.

This cleans up the command line parsing code. It also replaces the `--policies` option with `--use-ucb1-tuned` so that it's easier handled with the current setup.