### PR TITLE
Move command line setup into config

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -139,6 +139,21 @@ impl Config {
         }
     }
 
+    pub fn setup(&self, opts: &mut Options) {
+        opts.optflag("h", "help", "print this help menu");
+        opts.optflag("l", "log", "log to stderr (defaults to false)");
+        opts.optflag("v", "version", "print the version number");
+
+        opts.optopt("", "empty-area-prior", format!("prior value for empty areas (defaults to {})", self.uct.priors.empty).as_ref(), "NUM");
+        opts.optopt("", "reuse-subtree", "reuse the subtree from the previous search (defaults to true)", "true|false");
+        opts.optopt("", "use-atari-check-in-playouts", format!("Check for atari in the playouts (defaults to {}", self.playout.ladder_check).as_ref(), "true|false");
+        opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", self.uct.priors.use_empty).as_ref(), "true|false");
+        opts.optopt("", "use-ladder-check-in-playouts", format!("Check for ladders in the playouts (defaults to {}", self.playout.ladder_check).as_ref(), "true|false");
+        opts.optopt("", "use-ucb1-tuned", format!("Use the UCB1tuned selection strategy (defaults to {})", self.uct.tuned).as_ref(), "true|false");
+        opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
+        opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
+    }
+
     pub fn set_from_opts(&mut self, matches: &Matches, opts: &Options, args: &Vec<String>) -> Result<Option<String>, String>{
         if matches.opt_present("h") {
             let brief = format!("Usage: {} [options]", args[0]);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,7 @@ use ruleset::KgsChinese;
 use ruleset::Ruleset;
 use version;
 
+use core::fmt::Display;
 use getopts::Matches;
 use getopts::Options;
 
@@ -144,12 +145,12 @@ impl Config {
         opts.optflag("l", "log", "log to stderr (defaults to false)");
         opts.optflag("v", "version", "print the version number");
 
-        opts.optopt("", "empty-area-prior", format!("prior value for empty areas (defaults to {})", self.uct.priors.empty).as_ref(), "NUM");
-        opts.optopt("", "reuse-subtree", "reuse the subtree from the previous search (defaults to true)", "true|false");
-        opts.optopt("", "use-atari-check-in-playouts", format!("Check for atari in the playouts (defaults to {}", self.playout.ladder_check).as_ref(), "true|false");
-        opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", self.uct.priors.use_empty).as_ref(), "true|false");
-        opts.optopt("", "use-ladder-check-in-playouts", format!("Check for ladders in the playouts (defaults to {}", self.playout.ladder_check).as_ref(), "true|false");
-        opts.optopt("", "use-ucb1-tuned", format!("Use the UCB1tuned selection strategy (defaults to {})", self.uct.tuned).as_ref(), "true|false");
+        self.opt(opts, "empty-area-prior", "prior value for empty areas", self.uct.priors.empty);
+        self.opt(opts, "reuse-subtree", "reuse the subtree from the previous search", self.uct.reuse_subtree);
+        self.opt(opts, "use-atari-check-in-playouts", "Check for atari in the playouts", self.playout.ladder_check);
+        self.opt(opts, "use-empty-area-prior", "use a prior for empty areas on the board", self.uct.priors.use_empty);
+        self.opt(opts, "use-ladder-check-in-playouts", "Check for ladders in the playouts", self.playout.ladder_check);
+        self.opt(opts, "use-ucb1-tuned", "Use the UCB1tuned selection strategy", self.uct.tuned);
         opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
         opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
     }
@@ -187,4 +188,31 @@ impl Config {
             Ok(None)
         }
     }
+
+    fn opt<T: Display + Hint>(&self, opts: &mut Options, name: &'static str, descr: &'static str, default: T) {
+        opts.optopt("", name, format!("{} (defaults to {})", descr, default).as_ref(), default.hint_str());
+    }
+
+}
+
+trait Hint {
+
+    fn hint_str(&self) -> &'static str;
+
+}
+
+impl Hint for bool {
+
+    fn hint_str(&self) -> &'static str {
+        "true|false"
+    }
+}
+
+
+impl Hint for usize {
+
+    fn hint_str(&self) -> &'static str {
+        "NUM"
+    }
+
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -142,8 +142,9 @@ impl Config {
 
     pub fn setup(&self, opts: &mut Options) {
         opts.optflag("h", "help", "print this help menu");
-        opts.optflag("l", "log", "log to stderr (defaults to false)");
         opts.optflag("v", "version", "print the version number");
+
+        self.flag(opts, "l", "log", "log to stderr", self.log);
 
         self.opt(opts, "empty-area-prior", "prior value for empty areas", self.uct.priors.empty);
         self.opt(opts, "reuse-subtree", "reuse the subtree from the previous search", self.uct.reuse_subtree);
@@ -197,6 +198,9 @@ impl Config {
         self.optopt(opts, "", name, descr, default);
     }
 
+    fn flag(&self, opts: &mut Options, shortname: &'static str, name: &'static str, descr: &'static str, default: bool) {
+        opts.optflag(shortname, name, format!("{} (defaults to {})", descr, default).as_ref());
+    }
 }
 
 pub trait Hint {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,9 +71,9 @@ pub struct Config {
     pub uct: UctConfig,
 }
 
-macro_rules! opt {
+macro_rules! set_from_opt {
     ($matches:expr, $longopt:expr, $key:expr) => {
-        opt!($matches, "", $longopt, $key);
+        set_from_opt!($matches, "", $longopt, $key);
     };
     ($matches:expr, $shortopt:expr, $longopt:expr, $key:expr) => {
         if $matches.opt_present($longopt) {
@@ -93,9 +93,9 @@ macro_rules! opt {
     };
 }
 
-macro_rules! flag {
+macro_rules! set_from_flag {
     ($matches:expr, $longopt:expr, $key:expr) => {
-        flag!($matches, "", $longopt, $key);
+        set_from_flag!($matches, "", $longopt, $key);
     };
     ($matches:expr, $shortopt:expr, $longopt:expr, $key:expr) => {
         // Do it with an if so as to not override the default
@@ -165,16 +165,16 @@ impl Config {
             return Ok(Some(s));
         }
 
-        opt!(matches, "empty-area-prior", self.uct.priors.empty);
-        opt!(matches, "r", "ruleset", self.ruleset);
-        opt!(matches, "reuse-subtree", self.uct.reuse_subtree);
-        opt!(matches, "t", "threads", self.threads);
-        opt!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
-        opt!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
-        opt!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
-        opt!(matches, "use-ucb1-tuned", self.uct.tuned);
+        set_from_opt!(matches, "empty-area-prior", self.uct.priors.empty);
+        set_from_opt!(matches, "r", "ruleset", self.ruleset);
+        set_from_opt!(matches, "reuse-subtree", self.uct.reuse_subtree);
+        set_from_opt!(matches, "t", "threads", self.threads);
+        set_from_opt!(matches, "use-atari-check-in-playouts", self.playout.atari_check);
+        set_from_opt!(matches, "use-empty-area-prior", self.uct.priors.use_empty);
+        set_from_opt!(matches, "use-ladder-check-in-playouts", self.playout.ladder_check);
+        set_from_opt!(matches, "use-ucb1-tuned", self.uct.tuned);
 
-        flag!(matches, "l", "log", self.log);
+        set_from_flag!(matches, "l", "log", self.log);
 
         self.check()
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -151,8 +151,8 @@ impl Config {
         self.opt(opts, "use-empty-area-prior", "use a prior for empty areas on the board", self.uct.priors.use_empty);
         self.opt(opts, "use-ladder-check-in-playouts", "Check for ladders in the playouts", self.playout.ladder_check);
         self.opt(opts, "use-ucb1-tuned", "Use the UCB1tuned selection strategy", self.uct.tuned);
-        opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
-        opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
+        self.optopt(opts, "r", "ruleset", "select the ruleset", self.ruleset);
+        self.optopt(opts, "t", "threads", "number of threads to use", self.threads);
     }
 
     pub fn set_from_opts(&mut self, matches: &Matches, opts: &Options, args: &Vec<String>) -> Result<Option<String>, String>{
@@ -189,13 +189,17 @@ impl Config {
         }
     }
 
+    fn optopt<T: Display + Hint>(&self, opts: &mut Options, shortname: &'static str, name: &'static str, descr: &'static str, default: T) {
+        opts.optopt(shortname, name, format!("{} (defaults to {})", descr, default).as_ref(), default.hint_str());
+    }
+
     fn opt<T: Display + Hint>(&self, opts: &mut Options, name: &'static str, descr: &'static str, default: T) {
-        opts.optopt("", name, format!("{} (defaults to {})", descr, default).as_ref(), default.hint_str());
+        self.optopt(opts, "", name, descr, default);
     }
 
 }
 
-trait Hint {
+pub trait Hint {
 
     fn hint_str(&self) -> &'static str;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,20 +72,11 @@ pub fn main() {
     let mut config = Config::default();
     let mut opts = Options::new();
     let args : Vec<String> = args().collect();
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("l", "log", "log to stderr (defaults to false)");
-    opts.optflag("v", "version", "print the version number");
 
-    opts.optopt("", "empty-area-prior", format!("prior value for empty areas (defaults to {})", config.uct.priors.empty).as_ref(), "NUM");
-    opts.optopt("", "reuse-subtree", "reuse the subtree from the previous search (defaults to true)", "true|false");
-    opts.optopt("", "use-atari-check-in-playouts", format!("Check for atari in the playouts (defaults to {}", config.playout.ladder_check).as_ref(), "true|false");
-    opts.optopt("", "use-empty-area-prior", format!("use a prior for empty areas on the board (defaults to {:?})", config.uct.priors.use_empty).as_ref(), "true|false");
-    opts.optopt("", "use-ladder-check-in-playouts", format!("Check for ladders in the playouts (defaults to {}", config.playout.ladder_check).as_ref(), "true|false");
-    opts.optopt("", "use-ucb1-tuned", format!("Use the UCB1tuned selection strategy (defaults to {})", config.uct.tuned).as_ref(), "true|false");
     opts.optopt("e", "engine", "select an engine (defaults to uct)", "amaf|mc|random|uct");
     opts.optopt("p", "playout", "type of playout to use (defaults to no-self-atari)", "light|no-self-atari");
-    opts.optopt("r", "ruleset", "select the ruleset (defaults to chinese)", "cgos|chinese|tromp-taylor|minimal");
-    opts.optopt("t", "threads", "number of threads to use (defaults to 1)", "NUM");
+
+    config.setup(&mut opts);
 
     let matches = match opts.parse(args.tail()) {
         Ok(m) => m,

--- a/src/ruleset/mod.rs
+++ b/src/ruleset/mod.rs
@@ -20,11 +20,13 @@
  *                                                                      *
  ************************************************************************/
 
+use config::Hint;
 pub use self::Ruleset::AnySizeTrompTaylor;
 pub use self::Ruleset::CGOS;
 pub use self::Ruleset::KgsChinese;
 pub use self::Ruleset::Minimal;
 
+use std::fmt;
 use std::str::FromStr;
 
 mod test;
@@ -74,6 +76,27 @@ impl FromStr for Ruleset {
             "minimal"      => Ok(Minimal),
             _              => Err(format!("Unknown ruleset '{}'", s)),
         }
+    }
+
+}
+
+impl fmt::Display for Ruleset {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match *self {
+            AnySizeTrompTaylor => "tromp-taylor",
+            CGOS => "cgos",
+            KgsChinese => "chinese",
+            Minimal => "minimal"
+        };
+        s.fmt(f)
+    }
+}
+
+impl Hint for Ruleset {
+
+    fn hint_str(&self) -> &'static str {
+        "cgos|chinese|tromp-taylor|minimal"
     }
 
 }


### PR DESCRIPTION
This moves the command line option setup out of `main()`, too. I believe that this is better than what we had before, but it's still not ideal. Maybe I'll need to change this a bit so that both the definition of the command line option and the parsing code happen are located in the same spot. It seems to be entirely possible to do that with some anonymous functions or closures and maybe some syntactic sugar in the form of macros on top. But I'd rather do this in a separate pull request.