### PR TITLE
Benchmarks for the full UCT cycle

### DIFF
--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -185,8 +185,22 @@ fn expand_sets_the_descendant_count_if_the_node_was_expanded() {
 }
 
 #[bench]
-fn full_uct_cycle(b: &mut Bencher) {
-    let game = Game::new(13, 6.5, KgsChinese);
+fn full_uct_cycle_09x09(b: &mut Bencher) {
+    full_uct_cycle(19, b);
+}
+
+#[bench]
+fn full_uct_cycle_13x13(b: &mut Bencher) {
+    full_uct_cycle(13, b);
+}
+
+#[bench]
+fn full_uct_cycle_19x19(b: &mut Bencher) {
+    full_uct_cycle(19, b);
+}
+
+fn full_uct_cycle(size: u8, b: &mut Bencher) {
+    let game = Game::new(size, 6.5, KgsChinese);
     let mut config = Config::default();
     config.uct.priors.use_empty = true;
     let mut root = Node::root(&game, Black, config);
@@ -203,6 +217,7 @@ fn full_uct_cycle(b: &mut Bencher) {
         root.record_on_path(&path, winner, nodes_added);
     });
 }
+
 
 // 2. Make sure that terminal nodes are "played", i.e. either a win or
 //    a loss is reported and the wins are recorded in the tree.

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -27,11 +27,14 @@ use board::Play;
 use board::White;
 use config::Config;
 use game::Game;
+use playout;
 use ruleset::KgsChinese;
 use sgf::Parser;
 use super::Node;
 
+use rand::weak_rng;
 use std::path::Path;
+use test::Bencher;
 
 #[test]
 fn root_expands_the_children() {
@@ -181,6 +184,25 @@ fn expand_sets_the_descendant_count_if_the_node_was_expanded() {
     assert_eq!(25, node.descendants);
 }
 
+#[bench]
+fn full_uct_cycle(b: &mut Bencher) {
+    let game = Game::new(13, 6.5, KgsChinese);
+    let mut config = Config::default();
+    config.uct.priors.use_empty = true;
+    let mut root = Node::root(&game, Black, config);
+    let playout = playout::factory(None, config);
+    let mut rng = weak_rng();
+    b.iter(|| {
+        let (path, moves, _, nodes_added) = root.find_leaf_and_expand(&game);
+        let mut b = game.board();
+        for &m in moves.iter() {
+            b.play_legal_move(m);
+        }
+        let playout_result = playout.run(&mut b, None, &mut rng);
+        let winner = playout_result.winner();
+        root.record_on_path(&path, winner, nodes_added);
+    });
+}
 
 // 2. Make sure that terminal nodes are "played", i.e. either a win or
 //    a loss is reported and the wins are recorded in the tree.


### PR DESCRIPTION
Three new benchmarks that run one cycle of the UCT engine each (i.e. descending into the tree, expanding a leaf, running a playout, and updating the tree).