### PR TITLE
Resign faster

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,7 +127,7 @@ impl Config {
                 c: 0.5
             },
             uct: UctConfig {
-                end_of_game_cutoff: 0.01,
+                end_of_game_cutoff: 0.08,
                 expand_after: 1,
                 priors: UctPriorsConfig {
                     capture_many: 30,


### PR DESCRIPTION
In normal simulations, once your win rate goes down below 30% you've pretty much lost. But I have seen Iomrascalai be very confident and giving 80%+ when in a losing position. So because being on the other side would give under 20% win rate in a won position, I wouldn't suggest anything close to this.

1% being too low and wastes time in simulations and energy in simulating as many as a dozen extra moves on CGOS. 20% would be far too high. So I just went with a little less than half way just to be safe (resigning when we still have a chance is worse than playing out an additional move, so just to be safe the lower value is better).