### PR TITLE
Wrap the Config in an Arc

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -222,7 +222,6 @@ impl Board {
         self.komi = komi;
     }
 
-    #[test]
     pub fn set_ruleset(&mut self, ruleset: Ruleset) {
         self.ruleset = ruleset;
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -111,11 +111,11 @@ macro_rules! set_from_flag {
 
 impl Config {
 
-    pub fn play_out_aftermath(play_out_aftermath: bool) -> Config {
+    pub fn default() -> Config {
         Config {
             debug: true,
             log: false,
-            play_out_aftermath: play_out_aftermath,
+            play_out_aftermath: false,
             playout: PlayoutConfig {
                 atari_check: true,
                 ladder_check: true,
@@ -143,10 +143,6 @@ impl Config {
                 tuned: true,
             },
         }
-    }
-
-    pub fn default() -> Config {
-        Self::play_out_aftermath(false)
     }
 
     pub fn setup(&self, opts: &mut Options) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,16 +30,16 @@ use getopts::Options;
 
 mod test;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UctConfig {
     pub end_of_game_cutoff: f32,
-    pub expand_after: usize,
-    pub priors: UctPriorsConfig,
     pub reuse_subtree: bool,
     pub tuned: bool,
+    pub expand_after: usize,
+    pub priors: UctPriorsConfig,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UctPriorsConfig {
     pub capture_many: usize,
     pub capture_one: usize,
@@ -50,28 +50,28 @@ pub struct UctPriorsConfig {
     pub use_empty: bool,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TimerConfig {
     pub c: f32,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PlayoutConfig {
     pub atari_check: bool,
     pub ladder_check: bool,
-    pub no_self_atari_cutoff: usize,
     pub play_in_middle_of_eye: bool,
+    pub no_self_atari_cutoff: usize,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     pub debug: bool,
     pub log: bool,
     pub play_out_aftermath: bool,
-    pub playout: PlayoutConfig,
     pub ruleset: Ruleset,
-    pub threads: usize,
     pub timer: TimerConfig,
+    pub playout: PlayoutConfig,
+    pub threads: usize,
     pub uct: UctConfig,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -111,11 +111,11 @@ macro_rules! set_from_flag {
 
 impl Config {
 
-    pub fn default() -> Config {
+    pub fn play_out_aftermath(play_out_aftermath: bool) -> Config {
         Config {
             debug: true,
             log: false,
-            play_out_aftermath: false,
+            play_out_aftermath: play_out_aftermath,
             playout: PlayoutConfig {
                 atari_check: true,
                 ladder_check: true,
@@ -143,6 +143,10 @@ impl Config {
                 tuned: true,
             },
         }
+    }
+
+    pub fn default() -> Config {
+        Self::play_out_aftermath(false)
     }
 
     pub fn setup(&self, opts: &mut Options) {

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -27,6 +27,7 @@ use game::Game;
 use timer::Timer;
 use std::io::Write;
 
+use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
 use std::thread;
@@ -35,13 +36,13 @@ use std::thread::sleep_ms;
 mod test;
 
 pub struct EngineController<'a> {
-    config: Config,
+    config: Arc<Config>,
     engine: Box<Engine + 'a>,
 }
 
 impl<'a> EngineController<'a> {
 
-    pub fn new<'b>(config: Config, engine: Box<Engine + 'b>) -> EngineController<'b> {
+    pub fn new<'b>(config: Arc<Config>, engine: Box<Engine + 'b>) -> EngineController<'b> {
         EngineController {
             config: config,
             engine: engine,

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -22,6 +22,8 @@
 #![cfg(test)]
 #![allow(unused_must_use)]
 
+use std::sync::Arc;
+
 use board::Color;
 use board::Move;
 use board::Pass;
@@ -37,8 +39,8 @@ use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
 use time::PreciseTime;
 
-fn config() -> Config {
-    Config::default()
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
 }
 
 pub struct EarlyReturnEngine;
@@ -66,7 +68,7 @@ fn the_engine_can_use_less_time_than_allocated() {
     let timer = Timer::new(config());
     let budget = timer.budget(&game);
     let engine = Box::new(EarlyReturnEngine::new());
-    let mut controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(config(), engine);
     let start_time = PreciseTime::now();
     let (sender, receiver) = channel::<Move>();
     controller.run_and_return_move(color, &game, &timer, sender);
@@ -105,7 +107,7 @@ fn the_controller_asks_the_engine_for_a_move_when_the_time_is_up() {
     timer.setup(1, 0, 0);
     let budget = timer.budget(&game);
     let engine = Box::new(WaitingEngine::new());
-    let mut controller = EngineController::new(Config::default(), engine);
+    let mut controller = EngineController::new(config(), engine);
     let start_time = PreciseTime::now();
     let (sender, receiver) = channel::<Move>();
     controller.run_and_return_move(color, &game, &timer, sender);

--- a/src/engine/mc/amaf.rs
+++ b/src/engine/mc/amaf.rs
@@ -35,13 +35,13 @@ use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct AmafMcEngine {
-    config: Config,
+    config: Arc<Config>,
     playout: Arc<Box<Playout>>,
 }
 
 impl AmafMcEngine {
 
-    pub fn new(config: Config, playout: Box<Playout>) -> AmafMcEngine {
+    pub fn new(config: Arc<Config>, playout: Box<Playout>) -> AmafMcEngine {
         AmafMcEngine { config: config, playout: Arc::new(playout) }
     }
 
@@ -50,7 +50,7 @@ impl AmafMcEngine {
 impl Engine for AmafMcEngine {
 
     fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<AmafMcEngine>(self.config, self.playout.clone(), color, game, sender, receiver);
+        super::gen_move::<AmafMcEngine>(self.config.clone(), self.playout.clone(), color, game, sender, receiver);
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/mc/mod.rs
+++ b/src/engine/mc/mod.rs
@@ -52,7 +52,7 @@ pub trait McEngine {
 
 }
 
-fn gen_move<T: McEngine>(config: Config, playout: Arc<Box<Playout>>, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
+fn gen_move<T: McEngine>(config: Arc<Config>, playout: Arc<Box<Playout>>, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
     let moves = game.legal_moves_without_eyes();
     if moves.is_empty() {
         if config.log {
@@ -64,7 +64,7 @@ fn gen_move<T: McEngine>(config: Config, playout: Arc<Box<Playout>>, color: Colo
     let mut stats = MoveStats::new(&moves, color);
     let mut counter = 0;
     let (send_result, receive_result) = channel::<(MoveStats, usize)>();
-    let (_guards, halt_senders) = spin_up::<T>(color, config, playout.clone(), &moves, game, send_result);
+    let (_guards, halt_senders) = spin_up::<T>(color, config.clone(), playout.clone(), &moves, game, send_result);
     loop {
         select!(
             result = receive_result.recv() => {
@@ -102,7 +102,7 @@ fn finish(color: Color, game: &Game, stats: MoveStats, sender: Sender<Move>, hal
     }
 }
 
-fn spin_up<'a, T: McEngine>(color: Color, config: Config, playout: Arc<Box<Playout>>, moves: &'a Vec<Move>, game: &Game, send_result: Sender<(MoveStats, usize)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {
+fn spin_up<'a, T: McEngine>(color: Color, config: Arc<Config>, playout: Arc<Box<Playout>>, moves: &'a Vec<Move>, game: &Game, send_result: Sender<(MoveStats, usize)>) -> (Vec<thread::JoinGuard<'a, ()>>, Vec<Sender<()>>) {
     let mut guards = Vec::new();
     let mut halt_senders = Vec::new();
     for _ in 0..config.threads {

--- a/src/engine/mc/simple.rs
+++ b/src/engine/mc/simple.rs
@@ -35,13 +35,13 @@ use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
 pub struct SimpleMcEngine {
-    config: Config,
+    config: Arc<Config>,
     playout: Arc<Box<Playout>>,
 }
 
 impl SimpleMcEngine {
 
-    pub fn new(config: Config, playout: Box<Playout>) -> SimpleMcEngine {
+    pub fn new(config: Arc<Config>, playout: Box<Playout>) -> SimpleMcEngine {
         SimpleMcEngine { config: config, playout: Arc::new(playout) }
     }
 
@@ -50,7 +50,7 @@ impl SimpleMcEngine {
 impl Engine for SimpleMcEngine {
 
     fn gen_move(&mut self, color: Color, game: &Game, sender: Sender<Move>, receiver: Receiver<()>) {
-        super::gen_move::<SimpleMcEngine>(self.config, self.playout.clone(), color, game, sender, receiver);
+        super::gen_move::<SimpleMcEngine>(self.config.clone(), self.playout.clone(), color, game, sender, receiver);
     }
 
     fn engine_type(&self) -> &'static str {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -32,6 +32,7 @@ use game::Game;
 use playout::Playout;
 
 use std::ascii::OwnedAsciiExt;
+use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
@@ -42,7 +43,7 @@ mod random;
 mod test;
 mod uct;
 
-pub fn factory(opt: Option<String>, config: Config, playout: Box<Playout>) -> Box<Engine> {
+pub fn factory(opt: Option<String>, config: Arc<Config>, playout: Box<Playout>) -> Box<Engine> {
     let engine_arg = opt.map(|s| s.into_ascii_lowercase());
     match engine_arg {
         Some(s) => {

--- a/src/engine/test.rs
+++ b/src/engine/test.rs
@@ -21,12 +21,14 @@
 
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use config::Config;
 use playout::Playout;
 use playout;
 
-fn config() -> Config {
-    Config::default()
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
 }
 
 fn playout() -> Box<Playout> {

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -43,7 +43,9 @@ fn config() -> Arc<Config> {
 }
 
 fn play_out_aftermath(play_out_aftermath: bool) -> Arc<Config> {
-    Arc::new(Config::play_out_aftermath(play_out_aftermath))
+    let mut config = Config::default();
+    config.play_out_aftermath = play_out_aftermath;
+    Arc::new(config)
 }
 
 #[test]

--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -27,11 +27,12 @@ use super::GTPInterpreter;
 use version;
 
 use std::io::stdin;
+use std::sync::Arc;
 
 pub struct Driver;
 
 impl Driver {
-    pub fn new(config: Config, engine: Box<Engine>) {
+    pub fn new(config: Arc<Config>, engine: Box<Engine>) {
         let engine_name = format!("Iomrascalai ({})", engine.engine_type());
         let engine_version = version::version();
         let protocol_version = "2";

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -22,14 +22,20 @@
 
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use config::Config;
 use engine::RandomEngine;
 use super::Command;
 use super::GTPInterpreter;
 
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
+
 #[test]
 fn empty_string() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     let command = interpreter.read("");
     match command {
     	Command::Empty => (),
@@ -40,70 +46,70 @@ fn empty_string() {
 
 #[test]
 fn loadsgf_wrong_file() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf wrongfileactually\n");
     interpreter.quit();
 }
 
 #[test]
 fn loadsgf_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("loadsgf\n");
     interpreter.quit();
 }
 
 #[test]
 fn time_left_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("time_left\n");
     interpreter.quit();
 }
 
 #[test]
 fn time_settings_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("time_settings\n");
     interpreter.quit();
 }
 
 #[test]
 fn play_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("play\n");
     interpreter.quit();
 }
 
 #[test]
 fn genmove_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("genmove\n");
     interpreter.quit();
 }
 
 #[test]
 fn komi_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("komi\n");
     interpreter.quit();
 }
 
 #[test]
 fn boardsize_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("boardsize\n");
     interpreter.quit();
 }
 
 #[test]
 fn known_command_one_argument() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("known_command\n");
     interpreter.quit();
 }
 
 #[test]
 fn no_newline_at_end_of_list_commands() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     let commands    = interpreter.read("list_commands\n");
     let expected    = "boardsize\nclear_board\nfinal_score\ngenmove\nknown_command\nkomi\nlist_commands\nloadsgf\nname\nplay\nprotocol_version\nquit\nshowboard\ntime_left\ntime_settings\nversion";
     match commands {
@@ -115,7 +121,7 @@ fn no_newline_at_end_of_list_commands() {
 
 #[test]
 fn boardsize_sets_the_correct_size() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     assert_eq!(19, interpreter.game.size());
     interpreter.read("boardsize 9\n");
     interpreter.quit();
@@ -124,7 +130,7 @@ fn boardsize_sets_the_correct_size() {
 
 #[test]
 fn boardsize_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("boardsize 9\n");
     interpreter.quit();
@@ -133,7 +139,7 @@ fn boardsize_resets_the_board() {
 
 #[test]
 fn play_plays_a_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.quit();
     assert_eq!(360, interpreter.game.board().vacant_point_count());
@@ -141,7 +147,7 @@ fn play_plays_a_move() {
 
 #[test]
 fn sets_the_komi() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("komi 10\n");
     interpreter.quit();
     assert_eq!(10.0, interpreter.komi());
@@ -149,7 +155,7 @@ fn sets_the_komi() {
 
 #[test]
 fn sets_the_time() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("time_settings 30 20 10\n");
     interpreter.quit();
     assert_eq!(30_000, interpreter.timer.main_time);
@@ -159,7 +165,7 @@ fn sets_the_time() {
 
 #[test]
 fn clear_board_resets_the_board() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("play b a1\n");
     interpreter.read("clear_board\n");
     interpreter.quit();
@@ -168,7 +174,7 @@ fn clear_board_resets_the_board() {
 
 #[test]
 fn final_score_no_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     match interpreter.read("final_score\n") {
         Command::FinalScore(score) => assert_eq!("W+6.5", score),
         _                          => panic!("FinalScore expected!")
@@ -178,7 +184,7 @@ fn final_score_no_move() {
 
 #[test]
 fn final_score_one_move() {
-    let mut interpreter = GTPInterpreter::new(Config::default(), Box::new(RandomEngine::new()));
+    let mut interpreter = GTPInterpreter::new(config(), Box::new(RandomEngine::new()));
     interpreter.read("boardsize 4\n");
     interpreter.read("play b c2\n");
     match interpreter.read("final_score\n") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ use config::Config;
 use gtp::driver::Driver;
 
 use getopts::Options;
+use std::sync::Arc;
 use std::env::args;
 use std::io::Write;
 use std::process::exit;
@@ -104,9 +105,11 @@ pub fn main() {
         }
     }
 
-    let playout = playout::factory(matches.opt_str("p"), config);
+    let config = Arc::new(config);
 
-    let engine = engine::factory(matches.opt_str("e"), config, playout);
+    let playout = playout::factory(matches.opt_str("p"), config.clone());
+
+    let engine = engine::factory(matches.opt_str("e"), config.clone(), playout);
 
     log!("Current configuration: {:?}", config);
 

--- a/src/playout/no_eyes.rs
+++ b/src/playout/no_eyes.rs
@@ -24,6 +24,8 @@ use board::Move;
 use config::Config;
 use super::Playout;
 
+use std::sync::Arc;
+
 #[derive(Debug)]
 pub struct NoEyesPlayout;
 
@@ -36,15 +38,15 @@ impl Playout for NoEyesPlayout {
     fn playout_type(&self) -> &'static str {
         "no-eyes"
     }
-    
+
     fn check_for_ladders(&self) -> bool {
         false
     }
-    
+
     fn check_for_atari(&self) -> bool {
         false
     }
-    
+
     fn play_in_middle_of_eye(&self) -> bool {
         false
     }
@@ -53,12 +55,12 @@ impl Playout for NoEyesPlayout {
 //don't self atari strings that will make an eye after dying, which is strings of 7+
 #[derive(Debug)]
 pub struct NoSelfAtariPlayout {
-    config: Config
+    config: Arc<Config>
 }
 
 impl NoSelfAtariPlayout {
 
-    pub fn new(config: Config) -> NoSelfAtariPlayout {
+    pub fn new(config: Arc<Config>) -> NoSelfAtariPlayout {
         NoSelfAtariPlayout { config: config }
     }
 
@@ -79,7 +81,7 @@ impl Playout for NoSelfAtariPlayout {
     fn playout_type(&self) -> &'static str {
         "no-self-atari"
     }
-    
+
     fn check_for_ladders(&self) -> bool {
         self.config.playout.ladder_check
     }
@@ -87,7 +89,7 @@ impl Playout for NoSelfAtariPlayout {
     fn check_for_atari(&self) -> bool {
         self.config.playout.atari_check
     }
-    
+
     fn play_in_middle_of_eye(&self) -> bool {
         self.config.playout.play_in_middle_of_eye
     }

--- a/src/playout/test/mod.rs
+++ b/src/playout/test/mod.rs
@@ -21,12 +21,14 @@
 
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use config::Config;
 
 mod no_eyes;
 
-fn config() -> Config {
-    Config::default()
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
 }
 
 #[test]

--- a/src/playout/test/no_eyes.rs
+++ b/src/playout/test/no_eyes.rs
@@ -21,6 +21,8 @@
 
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use board::Black;
 use board::Board;
 use board::Play;
@@ -32,6 +34,10 @@ use ruleset::KgsChinese;
 
 use rand::weak_rng;
 use test::Bencher;
+
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
+}
 
 #[test]
 fn should_add_the_passed_moves_as_the_first_move() {
@@ -84,7 +90,7 @@ fn no_eyes_19x19(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_09x09(b: &mut Bencher) {
     let board = Board::new(9, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout::new(Config::default());
+    let playout = NoSelfAtariPlayout::new(config());
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();
@@ -95,7 +101,7 @@ fn no_self_atari_09x09(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_13x13(b: &mut Bencher) {
     let board = Board::new(13, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout::new(Config::default());
+    let playout = NoSelfAtariPlayout::new(config());
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();
@@ -106,7 +112,7 @@ fn no_self_atari_13x13(b: &mut Bencher) {
 #[bench]
 fn no_self_atari_19x19(b: &mut Bencher) {
     let board = Board::new(19, 6.5, KgsChinese);
-    let playout = NoSelfAtariPlayout::new(Config::default());
+    let playout = NoSelfAtariPlayout::new(config());
     let mut rng = weak_rng();
     b.iter(|| {
         let mut b = board.clone();

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -24,6 +24,8 @@ use game::Info;
 
 use time::precise_time_ns;
 
+use std::sync::Arc;
+
 mod test;
 
 #[derive(Clone)]
@@ -73,12 +75,12 @@ pub struct Timer {
     pub main_time: u32, // main time in ms
     main_time_left: u32,
     clock: Clock,
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl Timer {
 
-    pub fn new(config: Config) -> Timer {
+    pub fn new(config: Arc<Config>) -> Timer {
         Timer {
             byo_stones: 0,
             byo_stones_left: 0,

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -21,14 +21,16 @@
 
 #![cfg(test)]
 
+use std::sync::Arc;
+
 use config::Config;
 use game::Info;
 use super::Timer;
 
 use std::thread::sleep_ms;
 
-fn config() -> Config {
-    Config::default()
+fn config() -> Arc<Config> {
+    Arc::new(Config::default())
 }
 
 #[test]


### PR DESCRIPTION
This significantly reduces the size of many types by sharing the config
data between users. Notably, the `Node` type in the UCT engine has
shrunk from being 184 bytes to being 64 bytes. Given how many nodes are
allocated at any given time, this corresponds to a massive saving in
memory use.

I also tweaked the layout of the config data itself, since there was a fair bit of alignment padding. It won't make much of a difference now, but I couldn't help myself.

I also removed the `Copy` impl on the Config types to try to indicate that the type isn't actually that cheap to copy.