### PR TITLE
Speed up pattern matcher

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -96,15 +96,17 @@ impl Color {
 
 #[derive(Debug)]
 struct Cache {
-	diagonals: Vec<Vec<Coord>>,
-	neighbours: Vec<Vec<Coord>>,
+    diagonals: Vec<Vec<Coord>>,
+    neighbours: Vec<Vec<Coord>>,
+    neighbours8_unchecked: Vec<Vec<Coord>>
 }
 
 impl Cache {
     pub fn new(size: u8) -> Cache {
         Cache {
-            diagonals:             Cache::setup_diagonals(size),
-            neighbours:            Cache::setup_neighbours(size),
+            diagonals: Self::setup_diagonals(size),
+            neighbours: Self::setup_neighbours(size),
+            neighbours8_unchecked: Self::setup_neighbours8_unchecked(size),
         }
     }
 
@@ -122,6 +124,14 @@ impl Cache {
             diagonals.push(coord.diagonals(size));
         }
         diagonals
+    }
+
+    fn setup_neighbours8_unchecked(size: u8) -> Vec<Vec<Coord>> {
+        let mut neighbours8 = Vec::new();
+        for coord in Coord::for_board_size(size).iter() {
+            neighbours8.push(coord.neighbours8_unchecked());
+        }
+        neighbours8
     }
 }
 
@@ -187,6 +197,10 @@ impl Board {
 
     pub fn diagonals(&self, c: Coord) -> &Vec<Coord> {
         &self.cache.diagonals[c.to_index(self.size)]
+    }
+
+    pub fn neighbours8_unchecked(&self, c: Coord) -> &Vec<Coord> {
+        &self.cache.neighbours8_unchecked[c.to_index(self.size)]
     }
 
     pub fn points(&self) -> &Vec<Point> {

--- a/src/engine/uct/node/test.rs
+++ b/src/engine/uct/node/test.rs
@@ -390,7 +390,10 @@ fn full_uct_cycle_19x19(b: &mut Bencher) {
 
 fn full_uct_cycle(size: u8, b: &mut Bencher) {
     let game = Game::new(size, 6.5, KgsChinese);
-    let config = play_out_aftermath(true);
+    let mut cfg = Config::default();
+    cfg.play_out_aftermath = true;
+    cfg.uct.priors.use_patterns = true;
+    let config = Arc::new(cfg);
     let mut root = Node::root(&game, Black, config.clone());
     let playout = playout::factory(None, config.clone());
     let mut rng = weak_rng();

--- a/src/patterns/pattern/mod.rs
+++ b/src/patterns/pattern/mod.rs
@@ -39,7 +39,7 @@ impl Pattern {
     }
 
     pub fn matches(&self, board: &Board, coord: &Coord) -> bool {
-        coord.neighbours8_unchecked()
+        board.neighbours8_unchecked(*coord)
             .iter()
             .all(|nc| self.matches_at(board, coord, nc))
     }

--- a/src/patterns/pattern/mod.rs
+++ b/src/patterns/pattern/mod.rs
@@ -57,19 +57,23 @@ impl PointPattern {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Pattern {
-    vec: Vec<Vec<PointPattern>>
+    vec: Vec<PointPattern>
 }
 
 impl Pattern {
 
     pub fn new(vec: Vec<Vec<char>>) -> Pattern {
-        let v = vec
-            .iter()
-            .map(|sv| sv.iter().map(|c| PointPattern::from_char(c)).collect()).collect();
+        let mut v = vec!();
+        // Can be done with flat_map, I think.
+        for sv in vec.iter() {
+            for c in sv.iter() {
+                v.push(PointPattern::from_char(c));
+            }
+        }
         Pattern { vec: v }
     }
 
-    fn raw(vec: Vec<Vec<PointPattern>>) -> Pattern {
+    fn raw(vec: Vec<PointPattern>) -> Pattern {
         Pattern { vec: vec }
     }
 
@@ -111,7 +115,7 @@ impl Pattern {
         let offset_row = coord.row as isize - neighbour.row as isize;
         let col = (1 - offset_col) as usize;
         let row = (1 + offset_row) as usize;
-        self.vec[row][col]
+        self.at(row, col)
     }
 
     fn rotated(&self) -> Vec<Pattern> {
@@ -134,8 +138,7 @@ impl Pattern {
     fn swap(&self) -> Pattern {
         let swapped_vec = self.vec
             .iter()
-            .map(|subvec|
-                 subvec.iter().map(|c| self.swap_point_pattern(c)).collect())
+            .map(|pp| self.swap_point_pattern(pp))
             .collect();
         Pattern::raw(swapped_vec)
     }
@@ -153,37 +156,41 @@ impl Pattern {
     }
 
     fn rotated90(&self) -> Pattern {
-        let line1 = vec!(self.vec[2][0], self.vec[1][0], self.vec[0][0]);
-        let line2 = vec!(self.vec[2][1], self.vec[1][1], self.vec[0][1]);
-        let line3 = vec!(self.vec[2][2], self.vec[1][2], self.vec[0][2]);
-        Pattern::raw(vec!(line1, line2, line3))
+        Pattern::raw(vec!(
+            self.at(2,0), self.at(1,0), self.at(0,0),
+            self.at(2,1), self.at(1,1), self.at(0,1),
+            self.at(2,2), self.at(1,2), self.at(0,2)))
     }
 
     fn rotated180(&self) -> Pattern {
-        let line1 = vec!(self.vec[2][2], self.vec[2][1], self.vec[2][0]);
-        let line2 = vec!(self.vec[1][2], self.vec[1][1], self.vec[1][0]);
-        let line3 = vec!(self.vec[0][2], self.vec[0][1], self.vec[0][0]);
-        Pattern::raw(vec!(line1, line2, line3))
+        Pattern::raw(vec!(
+            self.at(2,2), self.at(2,1), self.at(2,0),
+            self.at(1,2), self.at(1,1), self.at(1,0),
+            self.at(0,2), self.at(0,1), self.at(0,0)))
     }
 
     fn rotated270(&self) -> Pattern {
-        let line1 = vec!(self.vec[0][2], self.vec[1][2], self.vec[2][2]);
-        let line2 = vec!(self.vec[0][1], self.vec[1][1], self.vec[2][1]);
-        let line3 = vec!(self.vec[0][0], self.vec[1][0], self.vec[2][0]);
-        Pattern::raw(vec!(line1, line2, line3))
+        Pattern::raw(vec!(
+            self.at(0,2), self.at(1,2), self.at(2,2),
+            self.at(0,1), self.at(1,1), self.at(2,1),
+            self.at(0,0), self.at(1,0), self.at(2,0)))
     }
 
     fn horizontally_flipped(&self) -> Pattern {
-        let line1 = vec!(self.vec[2][0], self.vec[2][1], self.vec[2][2]);
-        let line2 = vec!(self.vec[1][0], self.vec[1][1], self.vec[1][2]);
-        let line3 = vec!(self.vec[0][0], self.vec[0][1], self.vec[0][2]);
-        Pattern::raw(vec!(line1, line2, line3))
+        Pattern::raw(vec!(
+            self.at(2,0), self.at(2,1), self.at(2,2),
+            self.at(1,0), self.at(1,1), self.at(1,2),
+            self.at(0,0), self.at(0,1), self.at(0,2)))
     }
 
     fn vertically_flipped(&self) -> Pattern {
-        let line1 = vec!(self.vec[0][2], self.vec[0][1], self.vec[0][0]);
-        let line2 = vec!(self.vec[1][2], self.vec[1][1], self.vec[1][0]);
-        let line3 = vec!(self.vec[2][2], self.vec[2][1], self.vec[2][0]);
-        Pattern::raw(vec!(line1, line2, line3))
+        Pattern::raw(vec!(
+            self.at(0,2), self.at(0,1), self.at(0,0),
+            self.at(1,2), self.at(1,1), self.at(1,0),
+            self.at(2,2), self.at(2,1), self.at(2,0)))
+    }
+
+    fn at(&self, row: usize, col: usize) -> PointPattern {
+        self.vec[(row * 3) + col]
     }
 }


### PR DESCRIPTION
The `engine::uct::node::test::full_uct_cycle_13x13` with patterns turned off takes `541,316 ns/iter (+/- 94,850)`. Without the performance optimisations in this pull request but with the pattern matcher turned on it takes `1,567,389 ns/iter (+/- 296,077)`. With patterns turned on with this pull request we're down to `1,083,102 ns/iter (+/- 169,439)`.

Not yet ideal, but a good start. Next up I'll try building a tree out of the pattern so that matching should be even quicker.