### PR TITLE
Playout patterns only for last moves

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,6 +61,7 @@ pub struct TimerConfig {
 pub struct PlayoutConfig {
     pub atari_check: bool,
     pub ladder_check: bool,
+    pub last_moves_for_heuristics: usize,
     pub no_self_atari_cutoff: usize,
     pub pattern_probability: f32,
     pub play_in_middle_of_eye: bool,
@@ -123,6 +124,7 @@ impl Config {
             playout: PlayoutConfig {
                 atari_check: true,
                 ladder_check: true,
+                last_moves_for_heuristics: 2,
                 no_self_atari_cutoff: 7,
                 pattern_probability: 0.9,
                 play_in_middle_of_eye: true,

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -76,12 +76,13 @@ impl Playout {
     }
 
     fn heuristic_set(&self, played_moves: &Vec<Move>, board: &Board, rng: &mut XorShiftRng) -> Vec<Coord> {
-        let moves_to_consider = 2;
+        let moves_to_consider = self.config.playout.last_moves_for_heuristics as isize;
         let idx = cmp::max(played_moves.len() as isize - moves_to_consider,0) as usize;
         let moves = &played_moves[idx..played_moves.len()];
         let mut coords = vec!();
-        // The coords of the last move take precedence of the one
-        // before that.
+        // The neighbours of the latest move should come first as we
+        // select a matching move from the start of the vector and
+        // these should take precedence.
         for i in (0..moves.len()).rev() {
             if !moves[i].is_pass() {
                 let mut candidates : Vec<Coord> = board.neighbours(moves[i].coord()).iter().chain(board.diagonals(moves[i].coord())).cloned().collect();

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -21,6 +21,7 @@
 
 use board::Board;
 use board::Color;
+use board::Coord;
 use board::Move;
 use board::Pass;
 use board::Play;
@@ -29,6 +30,7 @@ use patterns::Matcher;
 
 use rand::Rng;
 use rand::XorShiftRng;
+use std::cmp;
 use std::sync::Arc;
 
 mod test;
@@ -54,7 +56,8 @@ impl Playout {
 
         let max_moves = self.max_moves(board.size());
         while !board.is_game_over() && played_moves.len() < max_moves {
-            let m = self.select_move(board, rng);
+            let heuristic_set = self.heuristic_set(&played_moves, board, rng);
+            let m = self.select_move(board, heuristic_set, rng);
             board.play_legal_move(m);
             played_moves.push(m);
         }
@@ -72,7 +75,28 @@ impl Playout {
         size as usize * size as usize * 3
     }
 
-    fn select_move(&self, board: &Board, rng: &mut XorShiftRng) -> Move {
+    fn heuristic_set(&self, played_moves: &Vec<Move>, board: &Board, rng: &mut XorShiftRng) -> Vec<Coord> {
+        let moves_to_consider = 2;
+        let idx = cmp::max(played_moves.len() as isize - moves_to_consider,0) as usize;
+        let moves = &played_moves[idx..played_moves.len()];
+        let mut coords = vec!();
+        // The coords of the last move take precedence of the one
+        // before that.
+        for i in (0..moves.len()).rev() {
+            if !moves[i].is_pass() {
+                let mut candidates : Vec<Coord> = board.neighbours(moves[i].coord()).iter().chain(board.diagonals(moves[i].coord())).cloned().collect();
+                rng.shuffle(&mut candidates);
+                for c in candidates {
+                    if !coords.contains(&c) {
+                        coords.push(c);
+                    }
+                }
+            }
+        }
+        coords
+    }
+
+    fn select_move(&self, board: &Board, heuristic_set: Vec<Coord>, rng: &mut XorShiftRng) -> Move {
         let color = board.next_player();
 
         if self.check_for_atari() {
@@ -82,7 +106,7 @@ impl Playout {
             }
         }
         if self.use_patterns(rng) {
-            let possible_move = self.pattern_move(color, board, rng);
+            let possible_move = self.pattern_move(color, heuristic_set, board);
             if possible_move.is_some() {
                 return possible_move.unwrap();
             }
@@ -114,26 +138,14 @@ impl Playout {
         }
     }
 
-    fn pattern_move(&self, color: Color, board: &Board, rng: &mut XorShiftRng) -> Option<Move> {
-        let vacant = board.vacant();
-        let playable = vacant
-            .iter()
+    fn pattern_move(&self, color: Color, coords: Vec<Coord>, board: &Board) -> Option<Move> {
+        // This works as coords is randomly ordered, so taking the
+        // first we find is OK.
+        coords.iter()
             .map(|c| Play(color, c.col, c.row))
-            .position(|m| {
+            .find(|&m| {
                 board.is_legal(m).is_ok() && self.matches(board, &m)
-            });
-        if let Some(first) = playable {
-            loop {
-                let r = first + (rng.gen::<usize>() % (vacant.len() - first));
-                let coord = vacant[r];
-                let m = Play(color, coord.col, coord.row);
-                if board.is_legal(m).is_ok() && self.matches(board, &m) {
-                    return Some(m);
-                }
-            }
-        } else {
-            None
-        }
+            })
     }
 
     fn matches(&self, board: &Board, m: &Move) -> bool {


### PR DESCRIPTION
As suggested by Petr (author of Pachi and Michi) the pattern check now only runs for the last two moves played. On 9x9 this increases the win percentage against GnuGo to **82.5% +/- 2.7**. :tada: The benchmark for 13x13 is still running. And I also haven't tried turning on the pattern prior so I will try that afterwards. But all in all, it seems like it's finally paying off!