### PR TITLE
Remove log! macro and use Config.log instead

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,8 @@ use version;
 use core::fmt::Display;
 use getopts::Matches;
 use getopts::Options;
+use std::io::Write;
+use std::io::stderr;
 
 mod test;
 
@@ -70,7 +72,6 @@ pub struct PlayoutConfig {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
-    pub debug: bool,
     pub log: bool,
     pub play_out_aftermath: bool,
     pub playout: PlayoutConfig,
@@ -118,7 +119,6 @@ impl Config {
 
     pub fn default() -> Config {
         Config {
-            debug: true,
             log: false,
             play_out_aftermath: false,
             playout: PlayoutConfig {
@@ -203,6 +203,15 @@ impl Config {
         set_from_flag!(matches, "l", "log", self.log);
 
         self.check()
+    }
+
+    pub fn log(&self, s: String) {
+        if self.log {
+            match stderr().write(format!("{}\n", s).as_bytes()) {
+                Ok(_) => {},
+                Err(x) => panic!("Unable to write to stderr: {}", x)
+            }
+        }
     }
 
     fn check(&self) -> Result<Option<String>, String> {

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -26,7 +26,6 @@ use engine::Engine;
 use game::Game;
 use timer::Timer;
 
-use std::io::Write;
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
@@ -88,9 +87,8 @@ impl<'a> EngineController<'a> {
 
     fn budget(&self, timer: &Timer, game: &Game) -> u32 {
         let budget = timer.budget(game);
-        if self.config.log {
-            log!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left());
-        }
+        self.config.log(
+            format!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left()));
         budget
     }
 

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -34,7 +34,6 @@ use timer::Timer;
 use strenum::Strenum;
 
 use num::traits::FromPrimitive;
-use std::io::Write;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
@@ -308,9 +307,7 @@ impl<'a> GTPInterpreter<'a> {
         let pps = (playouts as f64) / duration_s;
         let threads = config.threads;
         let ptps = pps / (threads as f64);
-        if config.log {
-            log!("{}pps ({}pps per thread)", pps.round() as usize, ptps.round() as usize);
-        }
+        config.log(format!("{}pps ({}pps per thread)", pps.round() as usize, ptps.round() as usize));
     }
 
     fn preprocess(&self, input: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,17 +52,7 @@ use patterns::Matcher;
 use getopts::Options;
 use std::sync::Arc;
 use std::env::args;
-use std::io::Write;
 use std::process::exit;
-
-macro_rules! log(
-    ($($arg:tt)*) => (
-        match writeln!(&mut ::std::io::stderr(), $($arg)* ) {
-            Ok(_) => {},
-            Err(x) => panic!("Unable to write to stderr: {}", x),
-        }
-    )
-);
 
 mod board;
 mod config;
@@ -118,7 +108,7 @@ pub fn main() {
 
     let engine = engine::factory(config.clone(), matcher);
 
-    log!("Current configuration: {:#?}", config);
+    config.log(format!("Current configuration: {:#?}", config));
 
     Driver::new(config, engine);
 }


### PR DESCRIPTION
The problem with the `log!` macro was that you had to add a `use std::io::Write` in every file that you used it in *and* you had to check the config anyway to check if the log flag was turned on.

Too bad that Rust doesn't have varargs or else I could have moved the `format!` call into `log()` as well.