### PR TITLE
Separate priors

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -31,18 +31,13 @@ FN="$PREFIX-${SIZE}x${SIZE}"
 
 set -x
 
-if [ ! -f "${FN}.html" ]; then
-    cargo clean
-    cargo build --release
+cargo clean
+cargo build --release
 
-    GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-    IOMRASCALAI="./target/release/iomrascalai -r chinese -t $THREADS -l"
-    REFEREE="$GNUGO"
+GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
+IOMRASCALAI="./target/release/iomrascalai -r chinese -t $THREADS -l"
+REFEREE="$GNUGO"
 
-    gogui-twogtp -auto -black "$GNUGO" -white "$IOMRASCALAI" \
-                 -size $SIZE -alternate -games $GAMES -sgffile $FN \
-                 -time $TIME -referee "$REFEREE" -verbose -debugtocomment
-    rm -f $FN.html
-    gogui-twogtp -analyze $FN.dat
-
-fi
+gogui-twogtp -auto -black "$GNUGO" -white "$IOMRASCALAI" \
+             -size $SIZE -alternate -games $GAMES -sgffile $FN \
+             -time $TIME -referee "$REFEREE" -verbose -debugtocomment

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,7 +137,7 @@ impl Config {
             },
             tree: TreeConfig {
                 end_of_game_cutoff: 0.08,
-                expand_after: 10,
+                expand_after: 0,
                 priors: PriorsConfig {
                     capture_many: 30,
                     capture_one: 15,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -138,7 +138,7 @@ impl Config {
             },
             tree: TreeConfig {
                 end_of_game_cutoff: 0.08,
-                expand_after: 0,
+                expand_after: 1,
                 priors: PriorsConfig {
                     best_move_factor: 1.0,
                     capture_many: 30,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,7 +137,7 @@ impl Config {
             },
             tree: TreeConfig {
                 end_of_game_cutoff: 0.08,
-                expand_after: 1,
+                expand_after: 10,
                 priors: PriorsConfig {
                     capture_many: 30,
                     capture_one: 15,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,7 @@ pub struct TreeConfig {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PriorsConfig {
+    pub best_move_factor: f32,
     pub capture_many: usize,
     pub capture_one: usize,
     pub empty: usize,
@@ -139,6 +140,7 @@ impl Config {
                 end_of_game_cutoff: 0.08,
                 expand_after: 0,
                 priors: PriorsConfig {
+                    best_move_factor: 1.0,
                     capture_many: 30,
                     capture_one: 15,
                     empty: 20,

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -46,6 +46,8 @@ pub struct Node {
     descendants: usize,
     m: Move,
     plays: usize,
+    prior_plays: usize,
+    prior_wins: usize,
     wins: usize,
 }
 
@@ -59,8 +61,10 @@ impl Node {
             config: config.clone(),
             descendants: 0,
             m: m,
-            plays: config.tree.priors.neutral_plays,
-            wins: config.tree.priors.neutral_wins,
+            plays: 0,
+            prior_plays: config.tree.priors.neutral_plays,
+            prior_wins: config.tree.priors.neutral_wins,
+            wins: 0,
         }
     }
 
@@ -200,57 +204,53 @@ impl Node {
     }
 
     pub fn priors(&self, children: &mut Vec<Node>, board: &Board) {
-            let color = board.next_player().opposite();
+        let color = board.next_player().opposite();
 
-            let in_danger = board.chains().iter()
-                .filter(|chain| chain.color() == color && chain.coords().len() == 1 && chain.liberties().len() <= 2);
+        let in_danger = board.chains().iter()
+            .filter(|chain| chain.color() == color && chain.coords().len() == 1 && chain.liberties().len() <= 2);
 
-            for one_stone in in_danger {
-                if let Some(solution) = board.capture_ladder(one_stone) {
-                    if let Some(node) = children.iter_mut().find(|c| c.m() == solution) {
-                        node.plays += self.config.tree.priors.capture_one;
-                        node.wins += self.config.tree.priors.capture_one;
-                    }
+        for one_stone in in_danger {
+            if let Some(solution) = board.capture_ladder(one_stone) {
+                if let Some(node) = children.iter_mut().find(|c| c.m() == solution) {
+                    node.record_even_prior(self.config.tree.priors.capture_one);
                 }
             }
+        }
 
-            let in_danger = board.chains().iter()
-                .filter(|chain| chain.color() == color && chain.coords().len() > 1 && chain.liberties().len() <= 2);
+        let in_danger = board.chains().iter()
+            .filter(|chain| chain.color() == color && chain.coords().len() > 1 && chain.liberties().len() <= 2);
 
-            for many_stones in in_danger {
-                if let Some(solution) = board.capture_ladder(many_stones) {
-                    if let Some(node) = children.iter_mut().find(|c| c.m() == solution) {
-                        node.plays += self.config.tree.priors.capture_many;
-                        node.wins += self.config.tree.priors.capture_many;
-                    }
+        for many_stones in in_danger {
+            if let Some(solution) = board.capture_ladder(many_stones) {
+                if let Some(node) = children.iter_mut().find(|c| c.m() == solution) {
+                    node.record_even_prior(self.config.tree.priors.capture_many);
                 }
             }
+        }
     }
 
     pub fn new_leaf(&self, board: &Board, m: &Move, matcher: Arc<Matcher>) -> Node {
         let mut node = Node::new(*m, self.config.clone());
 
         if !board.is_not_self_atari(m) {
-            node.plays += self.config.tree.priors.self_atari;
-            node.wins += 0; // That's a negative prior
+            // That's a negative prior
+            node.record_priors(self.config.tree.priors.self_atari, 0);
         }
         if self.config.tree.priors.use_empty {
             let distance = m.coord().distance_to_border(board.size());
             if distance <= 2 && self.in_empty_area(board, m) {
                 if distance <= 1 {
-                    node.plays += self.config.tree.priors.empty;
-                    node.wins += 0; // That's a negative prior
+                    // That's a negative prior
+                    node.record_priors(self.config.tree.priors.empty, 0);
                 } else {
-                    node.plays += self.config.tree.priors.empty;
-                    node.wins += self.config.tree.priors.empty;
+                    node.record_even_prior(self.config.tree.priors.empty);
                 }
             }
         }
         if self.config.tree.priors.use_patterns {
             let count = self.matching_patterns_count(board, m, matcher);
             let prior = count * self.config.tree.priors.patterns;
-            node.plays += prior;
-            node.wins += prior;
+            node.record_even_prior(prior);
         }
         node
     }
@@ -319,7 +319,7 @@ impl Node {
     }
 
     pub fn mostly_losses(&self, cutoff: f32) -> bool {
-        self.win_ratio() < cutoff
+        self.win_ratio_with_priors() < cutoff
     }
 
     pub fn record_win(&mut self) {
@@ -336,6 +336,15 @@ impl Node {
 
     pub fn record_amaf_play(&mut self) {
         self.amaf_plays += 1;
+    }
+
+    pub fn record_priors(&mut self, prior_plays: usize, prior_wins: usize) {
+        self.prior_plays += prior_plays;
+        self.prior_wins += prior_wins;
+    }
+
+    pub fn record_even_prior(&mut self, prior: usize) {
+        self.record_priors(prior, prior);
     }
 
     pub fn m(&self) -> Move {
@@ -359,7 +368,7 @@ impl Node {
 
     fn uct_tuned_value(&self, parent_plays: usize) -> f32 {
         const MAX_BERNOULLI_VARIANCE: f32 = 0.25;
-        let p = self.win_ratio(); //bernoulli distribution parameter
+        let p = self.win_ratio_with_priors(); //bernoulli distribution parameter
         let variance = p * (1.0 - p);
         let variance_upper_bound = variance + ((2.0 * (parent_plays as f32).ln())/(self.plays as f32)).sqrt();
         let smaller_upper_bound = MAX_BERNOULLI_VARIANCE.min(variance_upper_bound); //can't be greater than the theoretical variance
@@ -389,6 +398,16 @@ impl Node {
             let rave_winrate = aw / ap;
             let beta = ap / (ap + p + p * ap / rave_equiv);
             beta * rave_winrate + (1.0 - beta) * uct
+        }
+    }
+
+    fn win_ratio_with_priors(&self) -> f32 {
+        let p = self.plays + self.prior_plays;
+        if p == 0 {
+            0f32
+        } else {
+            let w = self.wins + self.prior_wins;
+            w as f32 / p as f32
         }
     }
 

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -311,7 +311,7 @@ impl Node {
     pub fn best(&self) -> &Node {
         let mut best = &self.children[0];
         for n in self.children.iter() {
-            if n.plays > best.plays {
+            if n.plays_with_priors() > best.plays_with_priors() {
                 best = n;
             }
         }
@@ -417,6 +417,10 @@ impl Node {
         } else {
             (self.wins as f32) / (self.plays as f32)
         }
+    }
+
+    fn plays_with_priors(&self) -> usize {
+        self.plays + self.prior_plays
     }
 
     pub fn color(&self) -> Color {

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -360,6 +360,9 @@ impl Node {
         self.plays as f32 + (self.prior_plays as f32 * self.config.tree.priors.best_move_factor)
     }
 
+    fn wins_with_prior_factor(&self) -> f32 {
+        self.wins as f32 + (self.prior_wins as f32 * self.config.tree.priors.best_move_factor)
+    }
 
     pub fn m(&self) -> Move {
         self.m
@@ -408,7 +411,7 @@ impl Node {
         } else {
             let aw = self.amaf_wins as f32;
             let ap = self.amaf_plays as f32;
-            let p = (self.plays + self.prior_plays) as f32;
+            let p = self.plays_with_prior_factor();
             let rave_equiv = self.config.tree.rave_equiv;
             let rave_winrate = aw / ap;
             let beta = ap / (ap + p + p * ap / rave_equiv);
@@ -417,12 +420,12 @@ impl Node {
     }
 
     fn win_ratio_with_priors(&self) -> f32 {
-        let p = self.plays + self.prior_plays;
-        if p == 0 {
-            0f32
+        let p = self.plays_with_prior_factor();
+        if p == 0.0 {
+            0.0
         } else {
-            let w = self.wins + self.prior_wins;
-            w as f32 / p as f32
+            let w = self.wins_with_prior_factor();
+            w / p
         }
     }
 

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -393,7 +393,7 @@ impl Node {
         } else {
             let aw = self.amaf_wins as f32;
             let ap = self.amaf_plays as f32;
-            let p = self.plays as f32;
+            let p = (self.plays + self.prior_plays) as f32;
             let rave_equiv = self.config.tree.rave_equiv;
             let rave_winrate = aw / ap;
             let beta = ap / (ap + p + p * ap / rave_equiv);

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -311,7 +311,7 @@ impl Node {
     pub fn best(&self) -> &Node {
         let mut best = &self.children[0];
         for n in self.children.iter() {
-            if n.plays_with_priors() > best.plays_with_priors() {
+            if n.plays > best.plays {
                 best = n;
             }
         }
@@ -417,10 +417,6 @@ impl Node {
         } else {
             (self.wins as f32) / (self.plays as f32)
         }
-    }
-
-    fn plays_with_priors(&self) -> usize {
-        self.plays + self.prior_plays
     }
 
     pub fn color(&self) -> Color {

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -70,6 +70,7 @@ impl Node {
 
     pub fn root(game: &Game, color: Color, config: Arc<Config>) -> Node {
         let mut root = Node::new(Pass(color), config);
+        root.reset();
         // So that we don't get NaN on the first UCT calculation
         root.plays = 1;
         // Now that plays is 1, this needs to be one too to keep the
@@ -98,12 +99,20 @@ impl Node {
         // Set these values to zero, as the new root is actually a
         // node of the opponent. Otherwise the win ratio would
         // approach 0% as we win the game. And then we would resign!
-        self.plays = 0;
-        self.wins = 0;
+        self.reset();
         // The root has to have the color of the player we want to
         // simulate. Otherwise the win statistics are for the wrong
         // player!
         self.m = Pass(color);
+    }
+
+    fn reset(&mut self) {
+        self.amaf_plays = 0;
+        self.amaf_wins = 0;
+        self.plays = 0;
+        self.prior_plays = 0;
+        self.prior_wins = 0;
+        self.wins = 0;
     }
 
     pub fn remove_illegal_children(&mut self, game: &Game) {

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -311,7 +311,7 @@ impl Node {
     pub fn best(&self) -> &Node {
         let mut best = &self.children[0];
         for n in self.children.iter() {
-            if n.plays > best.plays {
+            if n.plays_with_prior_factor() > best.plays_with_prior_factor() {
                 best = n;
             }
         }
@@ -322,30 +322,35 @@ impl Node {
         self.win_ratio_with_priors() < cutoff
     }
 
-    pub fn record_win(&mut self) {
+    fn record_win(&mut self) {
         self.wins += 1;
     }
 
-    pub fn record_amaf_win(&mut self) {
+    fn record_amaf_win(&mut self) {
         self.amaf_wins += 1;
     }
 
-    pub fn record_play(&mut self) {
+    fn record_play(&mut self) {
         self.plays += 1;
     }
 
-    pub fn record_amaf_play(&mut self) {
+    fn record_amaf_play(&mut self) {
         self.amaf_plays += 1;
     }
 
-    pub fn record_priors(&mut self, prior_plays: usize, prior_wins: usize) {
+    fn record_priors(&mut self, prior_plays: usize, prior_wins: usize) {
         self.prior_plays += prior_plays;
         self.prior_wins += prior_wins;
     }
 
-    pub fn record_even_prior(&mut self, prior: usize) {
+    fn record_even_prior(&mut self, prior: usize) {
         self.record_priors(prior, prior);
     }
+
+    fn plays_with_prior_factor(&self) -> f32 {
+        self.plays as f32 + self.prior_plays as f32 * self.config.tree.priors.best_move_factor
+    }
+
 
     pub fn m(&self) -> Move {
         self.m


### PR DESCRIPTION
Up until now the prior values were stored in the `plays` and `wins` fields in the `Node`. This made it difficult to say "expand leaves after 10 plays" as this heavily depended on the prior for the tree. It also skewed the statistics that were displayed on stderr and the win ratio included the priors!

Now the prior wins and plays are stored in separate fields but used in all calculations as before. To make checking that there's no bug in the implementation possible they are also used for selecting the best move. But it is *also* possible to weight them differently by using the `best_move_factor` config variable.

Win ratios:

|   | 9x9 | 13x13 | pps per thread on 19x19 |
|---|------|----------|----------------------------------|
| master | 85.5% +/- 4.99 | 32% +/- 6.61 | 98pps |
| `expand_after = 1`, `best_move_factor = 1.0` | 84.67% ± 4.06 | 34.67% ± 5.36 | 98pps |
| `expand_after = 10`, `best_move_factor = 0.0` | ? | ? | 95pps |
