### PR TITLE
Calculate 95% and 99% percent confidence intervals from test data

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,7 +6,7 @@ DIR=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
 cd "$DIR/.."
 
 THREADS=8
-GAMES=200
+GAMES=300
 
 if [ $1 == "9" ]; then
     TIME="5m"

--- a/bin/wins-from-benchmark-results.rb
+++ b/bin/wins-from-benchmark-results.rb
@@ -10,10 +10,17 @@ def wins(file)
   white = data(contents).find_all {|l| l =~ /W\+/ }.count
   black = data(contents).find_all {|l| l =~ /B\+/ }.count
   n = white + black
-  mean = (white.to_f/(white+black))*100
-  variance = (white * (100-mean) + black * mean) / (n-1)
-  sigma = Math.sqrt(variance) / 2
-  "#{mean.round(2)}% wins (#{white} games of #{n}, ± #{(2*sigma).round(2)} at 95%, ± #{(3*sigma).round(2)} at 99%)"
+  p = white.to_f/n
+  "#{(p*100).round(2)}% wins (#{white} games of #{n}, ± #{error(p: p, n: n, confidence: 0.95).round(2)} at 95%, ± #{error(p: p, n: n, confidence: 0.99).round(2)} at 99%)"
+end
+
+def z(confidence:)
+  alpha = 1 - confidence
+  (1 - 0.5*alpha)*2
+end
+
+def error(p:, n:, confidence:)
+  (z(confidence: confidence) * Math.sqrt((1.0/n)*p*(1-p)))*100
 end
 
 Dir["*.dat"].each do |fn|

--- a/bin/wins-from-benchmark-results.rb
+++ b/bin/wins-from-benchmark-results.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 def data(contents)
   contents.each_line.find_all {|l| l !~ /^#/ }.map do |l|
     l.split(/\s+/)[3]
@@ -8,8 +9,11 @@ def wins(file)
   contents = File.read(file)
   white = data(contents).find_all {|l| l =~ /W\+/ }.count
   black = data(contents).find_all {|l| l =~ /B\+/ }.count
-  percentage = white.to_f/(white+black)
-  "#{(percentage*100).round(2)}% wins (#{white} games of #{white+black})"
+  n = white + black
+  mean = (white.to_f/(white+black))*100
+  variance = (white * (100-mean) + black * mean) / (n-1)
+  sigma = Math.sqrt(variance) / 2
+  "#{mean.round(2)}% wins (#{white} games of #{n}, ± #{(2*sigma).round(2)} at 95%, ± #{(3*sigma).round(2)} at 99%)"
 end
 
 Dir["*.dat"].each do |fn|


### PR DESCRIPTION
It turns out that the error that gogui-twogtp reports is just the standard deviation. This of course means that the result will fall within that range 68% of the time only!

I've now enhanced my calculation script to report both the 2sigma (95% confidence) and 3sigma (99% confidence) intervals.

It appears that just running 200 games isn't really good enough (anymore) so I've also increases the number of games to play to 300.