### PR TITLE
Terminate early after 5% or 20% of the time when certain thresholds are met

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,6 +36,8 @@ mod test;
 pub struct TreeConfig {
     pub end_of_game_cutoff: f32,
     pub expand_after: usize,
+    pub fastplay20_thres: f32,
+    pub fastplay5_thres: f32,
     pub priors: PriorsConfig,
     pub rave_equiv: f32,
     pub reuse_subtree: bool,
@@ -139,6 +141,8 @@ impl Config {
             tree: TreeConfig {
                 end_of_game_cutoff: 0.08,
                 expand_after: 1,
+                fastplay20_thres: 0.8,
+                fastplay5_thres: 0.95,
                 priors: PriorsConfig {
                     best_move_factor: 1.0,
                     capture_many: 30,

--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -60,14 +60,22 @@ impl<'a> EngineController<'a> {
         // Saving the guard into a variable is necessary. Otherwise
         // the code blocks right here.
         unsafe {
+            let ste_config = self.config.clone();
             let _guard = scoped(|| {
-                self.engine.gen_move(color, game, send_move_to_controller, receive_signal_from_controller);
+                self.engine.gen_move(color, budget, game, send_move_to_controller, receive_signal_from_controller);
             });
 
             let (send_time_up_to_controller, receive_time_up) = channel();
             thread::spawn(move || {
                 sleep_ms(budget);
-                send_time_up_to_controller.send(()).unwrap();
+                match send_time_up_to_controller.send(()) {
+                    Ok(_) => {}
+                    Err(_) => {
+                        // This is expected to fail whenever the
+                        // engine returns before the allotted time is
+                        // up.
+                    }
+                }
             });
             select!(
                 r = receive_move_from_engine.recv() => {
@@ -76,7 +84,12 @@ impl<'a> EngineController<'a> {
                     playouts
                 },
                 _ = receive_time_up.recv() => {
-                    send_signal_to_engine.send(()).unwrap();
+                    match send_signal_to_engine.send(()) {
+                        Ok(_) => {},
+                        Err(e) => {
+                            ste_config.log(format!("[DEBUG] sending time up to engine failed with {:?}", e));
+                        }
+                    }
                     let (m, playouts) = receive_move_from_engine.recv().unwrap();
                     send_move.send(m).unwrap();
                     playouts

--- a/src/engine/controller/test.rs
+++ b/src/engine/controller/test.rs
@@ -55,7 +55,7 @@ impl EarlyReturnEngine {
 
 impl Engine for EarlyReturnEngine {
 
-    fn gen_move(&mut self, c: Color, _: &Game, sender: Sender<(Move,usize)>, _: Receiver<()>) {
+    fn gen_move(&mut self, c: Color, _: u32, _: &Game, sender: Sender<(Move,usize)>, _: Receiver<()>) {
         sender.send((Pass(c),0));
     }
 
@@ -90,7 +90,7 @@ impl WaitingEngine {
 
 impl Engine for WaitingEngine {
 
-    fn gen_move(&mut self, c: Color, _: &Game, sender: Sender<(Move,usize)>, receiver: Receiver<()>) {
+    fn gen_move(&mut self, c: Color, _: u32, _: &Game, sender: Sender<(Move,usize)>, receiver: Receiver<()>) {
         select!(
             _ = receiver.recv() => { sender.send((Pass(c),0)); }
         )

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -41,7 +41,7 @@ pub fn factory(config: Arc<Config>, matcher: Arc<Matcher>) -> Box<Engine> {
 
 pub trait Engine: Send + Sync {
 
-    fn gen_move(&mut self, Color, &Game, sender: Sender<(Move,usize)>, receiver: Receiver<()>);
+    fn gen_move(&mut self, Color, u32, &Game, sender: Sender<(Move,usize)>, receiver: Receiver<()>);
     fn reset(&mut self) {}
 
 }


### PR DESCRIPTION
If 5% of the allotted time has passed and the win ratio of the best move is above the 5% threshold terminate the search early. Same for the 20% case.

If this doesn't impact the strength of the program it should reduce the game length as the last moves as rather clear cut. And with shorter games the benchmark will run quicker.