### PR TITLE
Simplify config

### DIFF
--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -9,7 +9,7 @@ atari_check = true
 ladder_check = true
 last_moves_for_heuristics = 2
 pattern_probability = 0.9
-play_in_middle_of_eye = true
+play_in_middle_of_eye = 1.0
 
 [priors]
 

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -22,7 +22,6 @@ neutral_plays = 10
 neutral_wins = 5
 patterns = 10
 self_atari = 10
-use_empty = true
 use_patterns = true
 
 [time_control]

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -6,7 +6,7 @@ threads = 8
 [playout]
 
 atari_check = 1.0
-ladder_check = true
+ladder_check = 1.0
 last_moves_for_heuristics = 2
 pattern_probability = 0.9
 play_in_middle_of_eye = 1.0

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -21,7 +21,6 @@ neutral_plays = 10
 neutral_wins = 5
 patterns = 10
 self_atari = 10
-use_patterns = true
 
 [time_control]
 

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -10,7 +10,6 @@ ladder_check = true
 last_moves_for_heuristics = 2
 pattern_probability = 0.9
 play_in_middle_of_eye = true
-use_patterns = true
 
 [priors]
 

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -5,7 +5,7 @@ threads = 8
 
 [playout]
 
-atari_check = true
+atari_check = 1.0
 ladder_check = true
 last_moves_for_heuristics = 2
 pattern_probability = 0.9

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,9 +152,6 @@ pub struct PriorsConfig {
     /// in self atari. This is a negative prior (i.e. only prior plays
     /// are increased).
     pub self_atari: usize,
-    /// If set to `true` we check if a 3x3 pattern matches and use the
-    /// `patterns` prior.
-    pub use_patterns: bool,
 }
 
 impl PriorsConfig {
@@ -174,7 +171,6 @@ impl PriorsConfig {
             neutral_wins: Self::as_integer(&table, "neutral_wins"),
             patterns: Self::as_integer(&table, "patterns"),
             self_atari: Self::as_integer(&table, "self_atari"),
-            use_patterns: Self::as_bool(&table, "use_patterns"),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -225,9 +225,10 @@ pub struct PlayoutConfig {
     /// The probability of checking for atari moves (and playing one
     /// if there are any). Set to 1.0 to always check.
     pub atari_check: f32,
-    /// If set to `true` use the ladder checker (which is expensive)
-    /// during atari resolution.
-    pub ladder_check: bool,
+    /// The probability of using the ladder checker (which is
+    /// expensive) during atari resolution. Set to 1.0 to always use
+    /// it.
+    pub ladder_check: f32,
     /// The number of most recently played moves to consider when
     /// selecting moves based on heuristics.
     pub last_moves_for_heuristics: usize,
@@ -250,7 +251,7 @@ impl PlayoutConfig {
         table.extend(opts);
         PlayoutConfig {
             atari_check: Self::as_float(&table, "atari_check"),
-            ladder_check: Self::as_bool(&table, "ladder_check"),
+            ladder_check: Self::as_float(&table, "ladder_check"),
             last_moves_for_heuristics: Self::as_integer(&table, "last_moves_for_heuristics"),
             pattern_probability: Self::as_float(&table, "pattern_probability"),
             play_in_middle_of_eye: Self::as_float(&table, "play_in_middle_of_eye"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -222,9 +222,9 @@ impl FromToml for TimeControlConfig {
 /// Holds settings related to the playout policy
 #[derive(Debug, PartialEq)]
 pub struct PlayoutConfig {
-    /// If set to `true` check for atari in the playout and
-    /// immediately play the saving move if there is one.
-    pub atari_check: bool,
+    /// The probability of checking for atari moves (and playing one
+    /// if there are any). Set to 1.0 to always check.
+    pub atari_check: f32,
     /// If set to `true` use the ladder checker (which is expensive)
     /// during atari resolution.
     pub ladder_check: bool,
@@ -249,7 +249,7 @@ impl PlayoutConfig {
         table.extend(default_table);
         table.extend(opts);
         PlayoutConfig {
-            atari_check: Self::as_bool(&table, "atari_check"),
+            atari_check: Self::as_float(&table, "atari_check"),
             ladder_check: Self::as_bool(&table, "ladder_check"),
             last_moves_for_heuristics: Self::as_integer(&table, "last_moves_for_heuristics"),
             pattern_probability: Self::as_float(&table, "pattern_probability"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -237,7 +237,7 @@ pub struct PlayoutConfig {
     /// the playouts too much.
     pub pattern_probability: f32,
     /// ???
-    pub play_in_middle_of_eye: bool,
+    pub play_in_middle_of_eye: f32,
 }
 
 impl PlayoutConfig {
@@ -253,7 +253,7 @@ impl PlayoutConfig {
             ladder_check: Self::as_bool(&table, "ladder_check"),
             last_moves_for_heuristics: Self::as_integer(&table, "last_moves_for_heuristics"),
             pattern_probability: Self::as_float(&table, "pattern_probability"),
-            play_in_middle_of_eye: Self::as_bool(&table, "play_in_middle_of_eye"),
+            play_in_middle_of_eye: Self::as_float(&table, "play_in_middle_of_eye"),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,9 +152,6 @@ pub struct PriorsConfig {
     /// in self atari. This is a negative prior (i.e. only prior plays
     /// are increased).
     pub self_atari: usize,
-    /// If set to `true` we check if the move is in an empty area
-    /// close to the border and use the `empty` prior.
-    pub use_empty: bool,
     /// If set to `true` we check if a 3x3 pattern matches and use the
     /// `patterns` prior.
     pub use_patterns: bool,
@@ -177,7 +174,6 @@ impl PriorsConfig {
             neutral_wins: Self::as_integer(&table, "neutral_wins"),
             patterns: Self::as_integer(&table, "patterns"),
             self_atari: Self::as_integer(&table, "self_atari"),
-            use_empty: Self::as_bool(&table, "use_empty"),
             use_patterns: Self::as_bool(&table, "use_patterns"),
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -242,10 +242,6 @@ pub struct PlayoutConfig {
     pub pattern_probability: f32,
     /// ???
     pub play_in_middle_of_eye: bool,
-    /// If set to `true` then we try to match 3x3 patterns with
-    /// `pattern_probability`. If any patterns match we play one of
-    /// these moves.
-    pub use_patterns: bool,
 }
 
 impl PlayoutConfig {
@@ -262,7 +258,6 @@ impl PlayoutConfig {
             last_moves_for_heuristics: Self::as_integer(&table, "last_moves_for_heuristics"),
             pattern_probability: Self::as_float(&table, "pattern_probability"),
             play_in_middle_of_eye: Self::as_bool(&table, "play_in_middle_of_eye"),
-            use_patterns: Self::as_bool(&table, "use_patterns"),
         }
     }
 

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -245,7 +245,7 @@ impl Node {
             // That's a negative prior
             node.record_priors(self.config.priors.self_atari, 0);
         }
-        if self.config.priors.use_empty {
+        if self.use_empty() {
             let distance = m.coord().distance_to_border(board.size());
             if distance <= 2 && self.in_empty_area(board, m) {
                 if distance <= 1 {
@@ -440,5 +440,10 @@ impl Node {
     pub fn color(&self) -> Color {
         *self.m().color()
     }
+
+    fn use_empty(&self) -> bool {
+        self.config.priors.empty > 0
+    }
+
 
 }

--- a/src/engine/engine_impl/node/mod.rs
+++ b/src/engine/engine_impl/node/mod.rs
@@ -256,12 +256,16 @@ impl Node {
                 }
             }
         }
-        if self.config.priors.use_patterns {
+        if self.use_patterns() {
             let count = self.matching_patterns_count(board, m, matcher);
             let prior = count * self.config.priors.patterns;
             node.record_even_prior(prior);
         }
         node
+    }
+
+    fn use_patterns(&self) -> bool {
+        self.config.priors.patterns > 0
     }
 
     fn matching_patterns_count(&self, board: &Board, m: &Move, matcher: Arc<Matcher>) -> usize {

--- a/src/engine/engine_impl/node/test.rs
+++ b/src/engine/engine_impl/node/test.rs
@@ -406,7 +406,6 @@ fn full_uct_cycle(size: u8, b: &mut Bencher) {
     let mut cfg = Config::default();
     let matcher = matcher();
     cfg.play_out_aftermath = true;
-    cfg.priors.use_patterns = true;
     let config = Arc::new(cfg);
     let mut root = Node::root(&game, Black, config.clone());
     let playout = Playout::new(config.clone(), matcher.clone());

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -205,11 +205,7 @@ impl Playout {
     }
 
     fn use_patterns(&self, rng: &mut XorShiftRng) -> bool {
-        if self.config.playout.use_patterns {
-            rng.gen_range(0f32, 1f32) < self.config.playout.pattern_probability
-        } else {
-            false
-        }
+        rng.gen_range(0f32, 1f32) < self.config.playout.pattern_probability
     }
 
     fn play_in_middle_of_eye(&self) -> bool {

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -183,7 +183,7 @@ impl Playout {
                     if include_pass == 0 && !board.is_not_self_atari(&m) {
                         include_pass = 1; //try to pass in a seki sometimes
                     } else {
-                        return if self.play_in_middle_of_eye() {
+                        return if self.play_in_middle_of_eye(rng) {
                             board.play_in_middle_of_eye(m).unwrap_or(m)
                         } else {
                             m
@@ -205,11 +205,11 @@ impl Playout {
     }
 
     fn use_patterns(&self, rng: &mut XorShiftRng) -> bool {
-        rng.gen_range(0f32, 1f32) < self.config.playout.pattern_probability
+        rng.gen_range(0f32, 1f32) <= self.config.playout.pattern_probability
     }
 
-    fn play_in_middle_of_eye(&self) -> bool {
-        self.config.playout.play_in_middle_of_eye
+    fn play_in_middle_of_eye(&self, rng: &mut XorShiftRng) -> bool {
+        rng.gen_range(0f32, 1f32) <= self.config.playout.play_in_middle_of_eye
     }
 
 }

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -133,7 +133,7 @@ impl Playout {
             });
         match in_danger.next() {
             Some(chain) => {
-                let solutions = if self.check_for_ladders() {
+                let solutions = if self.check_for_ladders(rng) {
                     board.save_group(chain)
                 } else {
                     board.fix_atari_no_ladder_check(chain)
@@ -196,8 +196,8 @@ impl Playout {
         }
     }
 
-    fn check_for_ladders(&self) -> bool {
-        self.config.playout.ladder_check
+    fn check_for_ladders(&self, rng: &mut XorShiftRng) -> bool {
+        rng.gen_range(0f32, 1f32) <= self.config.playout.ladder_check
     }
 
     fn check_for_atari(&self, rng: &mut XorShiftRng) -> bool {

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -110,7 +110,7 @@ impl Playout {
     fn select_move(&self, board: &Board, heuristic_set: Vec<Coord>, rng: &mut XorShiftRng) -> Move {
         let color = board.next_player();
 
-        if self.check_for_atari() {
+        if self.check_for_atari(rng) {
             let possible_move = self.atari_move(color, board, rng);
             if possible_move.is_some() {
                 return possible_move.unwrap();
@@ -200,8 +200,8 @@ impl Playout {
         self.config.playout.ladder_check
     }
 
-    fn check_for_atari(&self) -> bool {
-        self.config.playout.atari_check
+    fn check_for_atari(&self, rng: &mut XorShiftRng) -> bool {
+        rng.gen_range(0f32, 1f32) <= self.config.playout.atari_check
     }
 
     fn use_patterns(&self, rng: &mut XorShiftRng) -> bool {


### PR DESCRIPTION
Simplify the configuration by removing all boolean flags. For the priors they are implicit when the prior values are set to 0 (e.g. setting the `patterns` prior to 0 is now equivalent to setting `use_patterns` to `false`) and the others are turned into probabilities with default values of 1.0.

