### PR TITLE
Fix pps display

### DIFF
--- a/src/engine/engine_impl/mod.rs
+++ b/src/engine/engine_impl/mod.rs
@@ -124,8 +124,9 @@ impl EngineImpl {
             self.config.log(format!("Returning the best move ({}% wins)", best_node.win_ratio()*100.0));
             best_node.m()
         };
+        let playouts = self.root.plays();
         self.set_new_root(&game.play(m).unwrap(), color);
-        (m,self.root.plays())
+        (m,playouts)
     }
 
     fn stop(&self, budget_ms: i64) -> bool {


### PR DESCRIPTION
Resetting the root node to the child node of the move that we're about to play and *then* getting the number of playouts of that node isn't a good idea. ;)