### PR TITLE
Move stop criteria into timer

### DIFF
--- a/src/engine/controller/mod.rs
+++ b/src/engine/controller/mod.rs
@@ -62,15 +62,7 @@ impl<'a> EngineController<'a> {
     }
 
     pub fn run_and_return_move(&mut self, color: Color, game: &Game, timer: &Timer) -> (Move, usize) {
-        let budget = self.budget(timer, game);
-        self.engine.genmove(color, budget, game)
-    }
-
-    fn budget(&self, timer: &Timer, game: &Game) -> i64 {
-        let budget = timer.budget(game);
-        self.config.log(
-            format!("Thinking for {}ms ({}ms time left)", budget, timer.main_time_left()));
-        budget
+        self.engine.genmove(color, game, timer)
     }
 
     fn ownership(&self) -> &OwnershipStatistics {

--- a/src/engine/engine_impl/mod.rs
+++ b/src/engine/engine_impl/mod.rs
@@ -146,7 +146,7 @@ impl Engine for EngineImpl {
         let (send_result_to_main, receive_result_from_threads) = channel::<((Vec<usize>, usize, PlayoutResult), Sender<(Vec<usize>, Vec<Move>, bool, usize)>)>();
         let (_guards, halt_senders) = spin_up(self.config.clone(), self.playout.clone(), game, send_result_to_main);
         loop {
-            if timer.ran_out_of_time(&self.root) {
+            if timer.ran_out_of_time(self.root.best().win_ratio()) {
                 return self.finish(game, color, halt_senders);
             }
             select!(

--- a/src/engine/engine_impl/mod.rs
+++ b/src/engine/engine_impl/mod.rs
@@ -32,7 +32,8 @@ use ownership::OwnershipStatistics;
 use patterns::Matcher;
 use playout::Playout;
 use playout::PlayoutResult;
-use self::node::Node;
+pub use self::node::Node;
+use timer::Timer;
 
 use rand::weak_rng;
 use std::sync::Arc;
@@ -41,7 +42,6 @@ use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
 use thread_scoped::JoinGuard;
 use thread_scoped::scoped;
-use time::Duration;
 use time::PreciseTime;
 
 mod node;
@@ -129,22 +129,6 @@ impl EngineImpl {
         (m,playouts)
     }
 
-    fn stop(&self, budget_ms: i64) -> bool {
-        let budget5 = Duration::milliseconds((budget_ms as f32 * 0.05) as i64);
-        let budget20 = Duration::milliseconds((budget_ms as f32 * 0.2) as i64);
-        let win_ratio = self.root.best().win_ratio();
-        let duration = self.start.to(PreciseTime::now());
-        if duration > budget5 && win_ratio > self.config.time_control.fastplay5_thres {
-            self.config.log(format!("Search stopped. 5% rule triggered"));
-            true
-        } else if duration > budget20 && win_ratio > self.config.time_control.fastplay20_thres {
-            self.config.log(format!("Search stopped. 20% rule triggered"));
-            true
-        } else {
-            duration > Duration::milliseconds(budget_ms)
-        }
-    }
-
 }
 
 impl Engine for EngineImpl {
@@ -153,7 +137,7 @@ impl Engine for EngineImpl {
         &self.ownership
     }
 
-    fn genmove(&mut self, color: Color, budget_ms: i64, game: &Game) -> (Move,usize) {
+    fn genmove(&mut self, color: Color, game: &Game, timer: &Timer) -> (Move,usize) {
         self.genmove_setup(color, game);
         if self.root.has_no_children() {
             self.config.log(format!("No moves to simulate!"));
@@ -162,7 +146,7 @@ impl Engine for EngineImpl {
         let (send_result_to_main, receive_result_from_threads) = channel::<((Vec<usize>, usize, PlayoutResult), Sender<(Vec<usize>, Vec<Move>, bool, usize)>)>();
         let (_guards, halt_senders) = spin_up(self.config.clone(), self.playout.clone(), game, send_result_to_main);
         loop {
-            if self.stop(budget_ms) {
+            if timer.ran_out_of_time(&self.root) {
                 return self.finish(game, color, halt_senders);
             }
             select!(

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,12 +21,14 @@
 
 pub use self::controller::EngineController;
 pub use self::engine_impl::EngineImpl;
+pub use self::engine_impl::Node;
 use board::Color;
 use board::Move;
 use config::Config;
 use game::Game;
 use ownership::OwnershipStatistics;
 use patterns::Matcher;
+use timer::Timer;
 
 use std::sync::Arc;
 
@@ -40,7 +42,7 @@ pub fn factory(config: Arc<Config>, matcher: Arc<Matcher>) -> Box<Engine> {
 
 pub trait Engine {
 
-    fn genmove(&mut self, Color, i64, &Game) -> (Move,usize);
+    fn genmove(&mut self, Color, &Game, &Timer) -> (Move,usize);
     fn ownership(&self) -> &OwnershipStatistics;
     fn reset(&mut self, u8) {}
 

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -196,7 +196,7 @@ impl<'a> GTPInterpreter<'a> {
         match arguments.get(0) {
             Some(comm) => {
                 let started_at = precise_time_ns();
-                self.timer.start();
+                self.timer.start(&self.game);
         	let color = Color::from_gtp(comm);
                 let (m, playouts) = self.controller.run_and_return_move(color, &self.game, &self.timer);
                 let response = match self.game.play(m) {
@@ -263,7 +263,7 @@ impl<'a> GTPInterpreter<'a> {
         match arguments.get(2) {
             Some(third) => {
             	//command[1] and command[2] should be there
-                match (arguments[0].parse::<u32>(), arguments[1].parse::<u32>(), third.parse::<i32>()) {
+                match (arguments[0].parse::<i64>(), arguments[1].parse::<i64>(), third.parse::<i32>()) {
                     (Ok(main), Ok(byo), Ok(stones)) => {
                         self.timer.setup(main, byo, stones);
                         Ok("".to_string())
@@ -278,7 +278,7 @@ impl<'a> GTPInterpreter<'a> {
     fn execute_time_left(&mut self, arguments: &[&str]) -> Result<String, String> {
         match arguments.get(2) {
             Some(third) => {
-                match (arguments[1].parse::<u32>(), third.parse::<i32>()) {
+                match (arguments[1].parse::<i64>(), third.parse::<i32>()) {
                     (Ok(time), Ok(stones)) => {
                         self.timer.update(time, stones);
                         Ok("".to_string())

--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -39,10 +39,13 @@ pub mod driver;
 mod test;
 
 pub struct GTPInterpreter<'a> {
+    byo_stones: i32,
+    byo_time: i64,
     commands: Vec<&'a str>,
     config: Arc<Config>,
     controller: EngineController<'a>,
     game: Game,
+    main_time: i64,
     running: bool,
     timer: Timer,
 }
@@ -74,10 +77,13 @@ impl<'a> GTPInterpreter<'a> {
             "version",
             ];
         GTPInterpreter {
+            byo_stones: 0,
+            byo_time: 0,
             commands: commands,
             config: config.clone(),
             controller: controller,
             game: Game::new(boardsize, komi, config.ruleset),
+            main_time: 5,
             running: true,
             timer: Timer::new(config),
         }
@@ -173,7 +179,7 @@ impl<'a> GTPInterpreter<'a> {
     fn execute_clear_board(&mut self, _: &[&str]) -> Result<String, String> {
         let size = self.boardsize();
         self.game = Game::new(size, self.komi(), self.ruleset());
-        self.timer.reset();
+        self.timer.setup(self.main_time, self.byo_time, self.byo_stones);
         self.controller.reset(size);
         Ok("".to_string())
     }
@@ -265,6 +271,9 @@ impl<'a> GTPInterpreter<'a> {
             	//command[1] and command[2] should be there
                 match (arguments[0].parse::<i64>(), arguments[1].parse::<i64>(), third.parse::<i32>()) {
                     (Ok(main), Ok(byo), Ok(stones)) => {
+                        self.main_time = main;
+                        self.byo_time = byo;
+                        self.byo_stones = stones;
                         self.timer.setup(main, byo, stones);
                         Ok("".to_string())
                     }

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -107,9 +107,9 @@ describe! interpreter {
             it "sets the time" {
                 let response = interpreter.read("time_settings 30 20 10\n");
                 assert_that(response, is(equal_to(ok(""))));
-                assert_that(interpreter.timer.main_time, is(equal_to(30_000)));
-                assert_that(interpreter.timer.byo_time, is(equal_to(20_000)));
-                assert_that(interpreter.timer.byo_stones, is(equal_to(10)));
+                assert_that(interpreter.timer.main_time(), is(equal_to(30_000)));
+                assert_that(interpreter.timer.byo_time(), is(equal_to(20_000)));
+                assert_that(interpreter.timer.byo_stones(), is(equal_to(10)));
             }
 
         }

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -107,9 +107,9 @@ describe! interpreter {
             it "sets the time" {
                 let response = interpreter.read("time_settings 30 20 10\n");
                 assert_that(response, is(equal_to(ok(""))));
-                assert_that(interpreter.timer.main_time(), is(equal_to(30_000)));
-                assert_that(interpreter.timer.byo_time(), is(equal_to(20_000)));
-                assert_that(interpreter.timer.byo_stones(), is(equal_to(10)));
+                assert_that(interpreter.main_time, is(equal_to(30)));
+                assert_that(interpreter.byo_time, is(equal_to(20)));
+                assert_that(interpreter.byo_stones, is(equal_to(10)));
             }
 
         }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -20,7 +20,6 @@
  ************************************************************************/
 
 use config::Config;
-use engine::Node;
 use game::Info;
 
 use std::cmp::max;
@@ -28,7 +27,7 @@ use std::sync::Arc;
 use time::Duration;
 use time::PreciseTime;
 
-// mod test;
+mod test;
 
 #[derive(Clone)]
 pub struct Timer {
@@ -52,7 +51,7 @@ impl Timer {
             byo_time_left: 0,
             config: config,
             current_budget: Duration::milliseconds(0),
-            main_time_left: 300000,
+            main_time_left: 0,
             time_stamp: PreciseTime::now(),
         }
 
@@ -87,10 +86,9 @@ impl Timer {
         self.config.log(msg);
     }
 
-    pub fn ran_out_of_time(&self, root: &Node) -> bool {
+    pub fn ran_out_of_time(&self, win_ratio: f32) -> bool {
         let budget5 = self.current_budget / 20;
         let budget20 = self.current_budget / 5;
-        let win_ratio = root.best().win_ratio();
         let elapsed = self.elapsed();
         if elapsed > budget5 && win_ratio > self.config.time_control.fastplay5_thres {
             self.config.log(format!("Search stopped. 5% rule triggered"));

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -20,62 +20,27 @@
  ************************************************************************/
 
 use config::Config;
+use engine::Node;
 use game::Info;
 
 use std::cmp::max;
 use std::sync::Arc;
-use time::precise_time_ns;
+use time::Duration;
+use time::PreciseTime;
 
-mod test;
-
-#[derive(Clone)]
-struct Clock {
-    start: Option<u64>,
-    end:   Option<u64>,
-}
-
-impl Clock {
-
-    pub fn new() -> Clock {
-        Clock {
-            start: None,
-            end:   None,
-        }
-    }
-
-    pub fn start(&mut self) {
-        self.start = Some(precise_time_ns());
-        self.end   = None;
-    }
-
-    pub fn stop(&mut self) {
-        self.end = Some(precise_time_ns());
-    }
-
-    fn time_elapsed_in_ms(&self) -> u32 {
-        match self.start {
-            Some(start) => {
-                match self.end {
-                    Some(end) => ((end - start) / 1000000) as u32,
-                    None      => 0
-                }
-            },
-            None => 0
-        }
-    }
-
-}
+// mod test;
 
 #[derive(Clone)]
 pub struct Timer {
-    pub byo_stones: i32, // stones per byo yomi period
     byo_stones_left: i32,
-    pub byo_time: u32, // byo yomi time in ms
-    byo_time_left: u32,
-    pub main_time: u32, // main time in ms
-    main_time_left: u32,
-    clock: Clock,
+    byo_time_left: i64,
     config: Arc<Config>,
+    current_budget: Duration,
+    main_time_left: i64,
+    byo_stones: i32,
+    byo_time: i64,
+    main_time: i64,
+    time_stamp: PreciseTime,
 }
 
 impl Timer {
@@ -86,10 +51,11 @@ impl Timer {
             byo_stones_left: 0,
             byo_time: 0,
             byo_time_left: 0,
+            config: config,
+            current_budget: Duration::milliseconds(0),
             main_time: 300000, // 5min
             main_time_left: 300000,
-            clock: Clock::new(),
-            config: config,
+            time_stamp: PreciseTime::now(),
         }
 
     }
@@ -98,17 +64,17 @@ impl Timer {
         self.main_time_left  = self.main_time;
         self.byo_time_left   = self.byo_time;
         self.byo_stones_left = self.byo_stones;
-        self.clock.stop();
+        self.reset_time_stamp();
     }
 
-    pub fn setup(&mut self, main_in_s: u32, byo_in_s: u32, stones: i32) {
+    pub fn setup(&mut self, main_in_s: i64, byo_in_s: i64, stones: i32) {
         self.set_main_time(main_in_s * 1000);
         self.set_byo_time(byo_in_s * 1000);
         self.set_byo_stones(stones);
-        self.clock.stop();
+        self.reset_time_stamp();
     }
 
-    pub fn update(&mut self, time_in_s: u32, stones: i32) {
+    pub fn update(&mut self, time_in_s: i64, stones: i32) {
         if stones == 0 {
             self.main_time_left = time_in_s * 1000;
         } else {
@@ -116,20 +82,89 @@ impl Timer {
             self.byo_time_left   = time_in_s * 1000;
             self.byo_stones_left = stones;
         }
-        self.start();
+        self.reset_time_stamp();
     }
 
-    pub fn start(&mut self) {
-        self.clock.start();
+    pub fn start<T: Info>(&mut self, game: &T) {
+        self.reset_time_stamp();
+        let budget = self.budget(game);
+        self.current_budget = budget;
+        let msg = format!(
+            "Thinking for {}ms ({}ms time left)",
+            budget.num_milliseconds(),
+            self.main_time_left());
+        self.config.log(msg);
+    }
+
+    pub fn ran_out_of_time(&self, root: &Node) -> bool {
+        let budget5 = self.current_budget / 20;
+        let budget20 = self.current_budget / 5;
+        let win_ratio = root.best().win_ratio();
+        let elapsed = self.elapsed();
+        if elapsed > budget5 && win_ratio > self.config.time_control.fastplay5_thres {
+            self.config.log(format!("Search stopped. 5% rule triggered"));
+            true
+        } else if elapsed > budget20 && win_ratio > self.config.time_control.fastplay20_thres {
+            self.config.log(format!("Search stopped. 20% rule triggered"));
+            true
+        } else {
+            elapsed > self.current_budget
+        }
     }
 
     pub fn stop(&mut self) {
-        self.clock.stop();
         self.adjust_time();
     }
 
+    pub fn byo_stones(&self) -> i32 {
+        self.byo_stones
+    }
+
+    pub fn byo_stones_left(&self) -> i32 {
+        self.byo_stones_left
+    }
+
+    pub fn byo_time(&self) -> i64 {
+        self.byo_time
+    }
+
+    pub fn byo_time_left(&self) -> i64 {
+        self.byo_time_left
+    }
+
+    pub fn main_time(&self) -> i64 {
+        self.main_time
+    }
+
+    pub fn main_time_left(&self) -> i64 {
+        self.main_time_left
+    }
+
+    fn set_main_time(&mut self, time: i64) {
+        self.main_time = time;
+        self.main_time_left = time;
+    }
+
+    fn set_byo_time(&mut self, time: i64) {
+        self.byo_time = time;
+        self.byo_time_left = time;
+    }
+
+    fn set_byo_stones(&mut self, stones: i32) {
+        self.byo_stones = stones;
+        self.byo_stones_left = stones;
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.time_stamp.to(PreciseTime::now())
+    }
+
+    fn reset_time_stamp(&mut self) {
+        self.time_stamp = PreciseTime::now();
+    }
+
     fn adjust_time(&mut self) {
-        let time_elapsed = self.clock.time_elapsed_in_ms();
+        let time_elapsed = self.elapsed().num_milliseconds();
 
         if time_elapsed > self.main_time_left {
             let overtime_spent = time_elapsed - self.main_time_left;
@@ -151,40 +186,13 @@ impl Timer {
         }
     }
 
-    pub fn main_time_left(&self) -> u32 {
-        self.main_time_left
-    }
-
-    pub fn byo_time_left(&self) -> u32 {
-        self.byo_time_left
-    }
-
-    pub fn byo_stones_left(&self) -> i32 {
-        self.byo_stones_left
-    }
-
-    fn set_main_time(&mut self, time: u32) {
-        self.main_time = time;
-        self.main_time_left = time;
-    }
-
-    fn set_byo_time(&mut self, time: u32) {
-        self.byo_time = time;
-        self.byo_time_left = time;
-    }
-
-    fn set_byo_stones(&mut self, stones: i32) {
-        self.byo_stones = stones;
-        self.byo_stones_left = stones;
-    }
-
     fn c(&self) -> f32 {
         self.config.time_control.c
     }
 
-    pub fn budget<T: Info>(&self, game: &T) -> i64 {
+    fn budget<T: Info>(&self, game: &T) -> Duration {
         // If there's still main time left
-        if self.main_time_left > 0 {
+        let ms = if self.main_time_left > 0 {
             // Assume at least 30 vacant points
             let vacant = max(game.vacant_point_count(), 30) as f32;
             (self.main_time_left as f32 / (self.c() * vacant)).floor() as i64
@@ -193,6 +201,7 @@ impl Timer {
         } else {
             // Else use byoyomi time
             (self.byo_time_left() as f32 / self.byo_stones_left() as f32).floor() as i64
-        }
+        };
+        Duration::milliseconds(ms)
     }
 }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -32,14 +32,13 @@ use time::PreciseTime;
 
 #[derive(Clone)]
 pub struct Timer {
+    byo_stones: i32,
     byo_stones_left: i32,
+    byo_time: i64,
     byo_time_left: i64,
     config: Arc<Config>,
     current_budget: Duration,
     main_time_left: i64,
-    byo_stones: i32,
-    byo_time: i64,
-    main_time: i64,
     time_stamp: PreciseTime,
 }
 
@@ -53,18 +52,10 @@ impl Timer {
             byo_time_left: 0,
             config: config,
             current_budget: Duration::milliseconds(0),
-            main_time: 300000, // 5min
             main_time_left: 300000,
             time_stamp: PreciseTime::now(),
         }
 
-    }
-
-    pub fn reset(&mut self) {
-        self.main_time_left  = self.main_time;
-        self.byo_time_left   = self.byo_time;
-        self.byo_stones_left = self.byo_stones;
-        self.reset_time_stamp();
     }
 
     pub fn setup(&mut self, main_in_s: i64, byo_in_s: i64, stones: i32) {
@@ -116,24 +107,12 @@ impl Timer {
         self.adjust_time();
     }
 
-    pub fn byo_stones(&self) -> i32 {
-        self.byo_stones
-    }
-
     pub fn byo_stones_left(&self) -> i32 {
         self.byo_stones_left
     }
 
-    pub fn byo_time(&self) -> i64 {
-        self.byo_time
-    }
-
     pub fn byo_time_left(&self) -> i64 {
         self.byo_time_left
-    }
-
-    pub fn main_time(&self) -> i64 {
-        self.main_time
     }
 
     pub fn main_time_left(&self) -> i64 {
@@ -141,7 +120,6 @@ impl Timer {
     }
 
     fn set_main_time(&mut self, time: i64) {
-        self.main_time = time;
         self.main_time_left = time;
     }
 

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -21,162 +21,21 @@
 
 #![cfg(test)]
 
-use config::Config;
-use game::Info;
-use super::Timer;
+pub use board::Black;
+pub use config::Config;
+pub use game::Info;
+pub use ruleset::KgsChinese;
+pub use super::Timer;
 
-use std::sync::Arc;
-use std::thread::sleep;
-use std::time::Duration;
+pub use hamcrest::assert_that;
+pub use hamcrest::close_to;
+pub use hamcrest::equal_to;
+pub use hamcrest::is;
+pub use std::sync::Arc;
+pub use time::Duration;
+pub use time::PreciseTime;
 
-fn config() -> Arc<Config> {
-    Arc::new(Config::default())
-}
-
-#[test]
-fn the_timer_has_a_default_of_5_min_sudden_death() {
-    let timer = Timer::new(config());
-    assert_eq!(5*60*1000, timer.main_time);
-    assert_eq!(0, timer.byo_time);
-    assert_eq!(0, timer.byo_stones);
-}
-
-#[test]
-fn reset_resets_everything() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left  = 1;
-    timer.byo_time_left   = 1;
-    timer.byo_stones_left = 1;
-    timer.reset();
-    assert_eq!(timer.main_time, timer.main_time_left);
-    assert_eq!(timer.byo_time, timer.byo_time_left);
-    assert_eq!(timer.byo_stones, timer.byo_stones_left);
-}
-
-#[test]
-fn update_converts_to_ms_and_resets_everything() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left  = 1;
-    timer.byo_time_left   = 1;
-    timer.byo_stones_left = 1;
-    timer.setup(2, 2, 2);
-    assert_eq!(2000, timer.main_time);
-    assert_eq!(2000, timer.main_time_left);
-    assert_eq!(2000, timer.byo_time);
-    assert_eq!(2000, timer.byo_time_left);
-    assert_eq!(2, timer.byo_stones);
-    assert_eq!(2, timer.byo_stones_left);
-}
-
-#[test]
-fn update_sets_the_main_time() {
-    let mut timer = Timer::new(config());
-    timer.update(1, 0);
-    assert_eq!(1000, timer.main_time_left);
-}
-
-#[test]
-fn update_sets_the_byo_time() {
-    let mut timer = Timer::new(config());
-    timer.update(1, 1);
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(1000, timer.byo_time_left);
-    assert_eq!(1, timer.byo_stones_left);
-}
-
-
-#[test]
-fn stop_changes_the_time_left() {
-    let mut timer = Timer::new(config());
-    let info = TestGameInfo::new(0);
-    timer.start(&info);
-    sleep(Duration::from_millis(10));
-    timer.stop();
-    assert!(timer.main_time_left < timer.main_time);
-}
-
-#[test]
-fn adjust_time_updates_the_main_time() {
-    let mut timer = Timer::new(config());
-    assert_eq!(5*60*1000, timer.main_time_left);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000);
-    timer.adjust_time();
-    assert_eq!(5*60*1000-1, timer.main_time_left);
-}
-
-#[test]
-fn adjust_time_updates_the_byo_time() {
-    let mut timer = Timer::new(config());
-    timer.setup(0, 1, 2);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000);
-    timer.adjust_time();
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(999, timer.byo_time_left);
-}
-
-#[test]
-fn adjust_time_updates_the_byo_stones() {
-    let mut timer = Timer::new(config());
-    timer.setup(0, 1, 2);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000);
-    timer.adjust_time();
-    assert_eq!(1, timer.byo_stones_left);
-}
-
-#[test]
-fn adjust_time_resets_the_byo_time_after_the_last_move() {
-    let mut timer = Timer::new(config());
-    timer.setup(0, 1, 2);
-    timer.byo_time_left   = 500;
-    timer.byo_stones_left = 1;
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000);
-    timer.adjust_time();
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(1000, timer.byo_time_left);
-    assert_eq!(2, timer.byo_stones_left);
-}
-
-#[test]
-fn adjust_time_splits_time_between_main_and_byo_time() {
-    let mut timer = Timer::new(config());
-    timer.setup(1, 2, 2);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000*1000*2);
-    timer.adjust_time();
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(1000, timer.byo_time_left);
-    assert_eq!(1, timer.byo_stones_left);
-}
-
-#[test]
-fn adjust_time_sets_remaining_time_to_zero_in_absolute_time_if_time_is_over() {
-    let mut timer = Timer::new(config());
-    timer.setup(1, 0, 0);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000*1000*2);
-    timer.adjust_time();
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(0, timer.byo_time_left);
-    assert_eq!(0, timer.byo_stones_left);
-}
-
-#[test]
-fn adjust_time_sets_remaining_time_to_zero_in_byo_time_if_time_is_over() {
-    let mut timer = Timer::new(config());
-    timer.setup(0, 1, 0);
-    timer.clock.start = Some(0);
-    timer.clock.end   = Some(1000000*1000*2);
-    timer.adjust_time();
-    assert_eq!(0, timer.main_time_left);
-    assert_eq!(0, timer.byo_time_left);
-    assert_eq!(0, timer.byo_stones_left);
-}
-
-struct TestGameInfo {
+pub struct TestGameInfo {
     vacant_points: u16
 }
 
@@ -196,48 +55,299 @@ impl Info for TestGameInfo {
 
 }
 
-#[test]
-fn budget_returns_zero_if_the_time_is_over() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left  = 0;
-    timer.byo_time_left   = 0;
-    timer.byo_stones_left = 0;
-    let info = TestGameInfo::new(0);
-    assert_eq!(0, timer.budget(&info));
+// This sleep function doesn't take a Duration from the time crate but
+// one from the std library.
+pub fn sleep_ms(ms: u64) {
+    ::std::thread::sleep(::std::time::Duration::from_millis(ms));
 }
 
-#[test]
-fn budget_returns_a_fraction_of_the_byo_time_remaining() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left  = 0;
-    timer.byo_time_left   = 2;
-    timer.byo_stones_left = 2;
-    let info = TestGameInfo::new(0);
-    assert_eq!(1, timer.budget(&info));
-}
+describe! timer {
 
-#[test]
-fn budget_rounds_down_when_calculating_the_byo_time() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left  = 0;
-    timer.byo_time_left   = 3;
-    timer.byo_stones_left = 2;
-    let info = TestGameInfo::new(0);
-    assert_eq!(1, timer.budget(&info));
-}
+    before_each {
+        let mut c = Config::default();
+        c.time_control.c = 0.5;
+        let config = Arc::new(c);
+        let mut timer = Timer::new(config.clone());
+    }
 
-#[test]
-fn budget_during_main_time_uses_the_vacant_points_to_calculate_the_time() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left = 100;
-    let info = TestGameInfo::new(100);
-    assert_eq!(2, timer.budget(&info));
-}
+    describe! setup {
 
-#[test]
-fn budget_during_main_time_uses_a_minimum_of_30_for_vacant_points() {
-    let mut timer = Timer::new(config());
-    timer.main_time_left = 100;
-    let info = TestGameInfo::new(10);
-    assert_eq!(6, timer.budget(&info));
+        it "sets the main time" {
+            timer.setup(30, 20, 10);
+            assert_that(timer.main_time_left, is(equal_to(30_000)));
+        }
+
+        it "sets the byoyomi time" {
+            timer.setup(30, 20, 10);
+            assert_that(timer.byo_time, is(equal_to(20_000)));
+            assert_that(timer.byo_time_left, is(equal_to(20_000)));
+        }
+
+        it "sets the byoyomi stones" {
+            timer.setup(30, 20, 10);
+            assert_that(timer.byo_stones, is(equal_to(10)));
+            assert_that(timer.byo_stones_left, is(equal_to(10)));
+        }
+
+        it "resets the time stamp" {
+            let previous_time_stamp = timer.time_stamp;
+            timer.setup(30, 20, 10);
+            assert!(previous_time_stamp.to(PreciseTime::now()) > Duration::seconds(0));
+        }
+
+    }
+
+    describe! update {
+
+        describe! main_time {
+
+            it "sets the main time" {
+                timer.update(30, 0);
+                assert_that(timer.main_time_left, is(equal_to(30_000)));
+            }
+
+            it "doesn't change the byoyomi time" {
+                let byo_time_left_before = timer.byo_time_left;
+                timer.update(30, 0);
+                assert_that(timer.byo_time_left, is(equal_to(byo_time_left_before)));
+            }
+
+            it "doesn't change the byoyomi stones" {
+                let byo_stones_left_before = timer.byo_stones_left;
+                timer.update(30, 0);
+                assert_that(timer.byo_stones_left, is(equal_to(byo_stones_left_before)));
+            }
+
+            it "updates the time stamp" {
+                let previous_time_stamp = timer.time_stamp;
+                timer.update(30, 0);
+                assert!(previous_time_stamp.to(PreciseTime::now()) > Duration::seconds(0));
+            }
+
+        }
+
+        describe! over_time {
+
+            it "sets the main time to 0" {
+                timer.update(30, 5);
+                assert_that(timer.main_time_left, is(equal_to(0)));
+            }
+
+            it "sets the byoyomi time" {
+                timer.update(30, 5);
+                assert_that(timer.byo_time_left, is(equal_to(30_000)));
+            }
+
+            it "sets the byoyomi stones" {
+                timer.update(30, 5);
+                assert_that(timer.byo_stones_left, is(equal_to(5)));
+            }
+
+            it "updates the time stamp" {
+                let previous_time_stamp = timer.time_stamp;
+                timer.update(30, 5);
+                assert!(previous_time_stamp.to(PreciseTime::now()) > Duration::seconds(0));
+            }
+
+        }
+
+
+    }
+
+    describe! start {
+
+        it "updates the timestamp" {
+            let previous_time_stamp = timer.time_stamp;
+            timer.start(&TestGameInfo::new(0));
+            assert!(previous_time_stamp.to(PreciseTime::now()) > Duration::seconds(0));
+        }
+
+        it "sets the current budget" {
+            let previous_budget = timer.current_budget;
+            timer.setup(30, 0, 0);
+            timer.start(&TestGameInfo::new(9));
+            assert!(timer.current_budget > previous_budget);
+        }
+    }
+
+    describe! budget {
+
+        it "returns zero if there's no time left" {
+            timer.setup(0, 0, 0);
+            let game_info = &TestGameInfo::new(0);
+            assert_that(timer.budget(game_info).num_milliseconds(), is(equal_to(0)));
+        }
+
+        it "returns a fraction of the byo time" {
+            timer.setup(0, 2, 2);
+            let game_info = &TestGameInfo::new(0);
+            assert_that(timer.budget(game_info).num_milliseconds(), is(equal_to(1_000)));
+        }
+
+        it "uses the vacant points to calculate during main time" {
+            timer.setup(100, 0, 0);
+            let game_info = &TestGameInfo::new(100);
+            assert_that(timer.budget(game_info).num_milliseconds(), is(equal_to(2_000)));
+        }
+
+        it "uses a minimum of 30 points to calculate during main time" {
+            timer.setup(300, 0, 0);
+            let game_info = &TestGameInfo::new(10);
+            assert_that(timer.budget(game_info).num_milliseconds(), is(equal_to(20_000)));
+        }
+    }
+
+    describe! stop {
+
+        it "changes the time settings" {
+            timer.setup(300, 0, 0);
+            sleep_ms(10);
+            let previous_time_left = timer.main_time_left;
+            timer.stop();
+            assert!(timer.main_time_left < previous_time_left);
+        }
+    }
+
+    describe! adjust_time {
+
+        describe! main_time {
+
+            before_each {
+                timer.setup(300, 100, 10);
+            }
+
+            it "updates the main time left" {
+                let previous_main_time_left = timer.main_time_left;
+                sleep_ms(10);
+                let elapsed = timer.time_stamp.to(PreciseTime::now()).num_milliseconds();
+                timer.adjust_time();
+                let expected_new_time_left = (previous_main_time_left - elapsed) as f32;
+                assert_that(timer.main_time_left as f32, is(close_to(expected_new_time_left, 5.0)));
+            }
+
+            it "doesn't change the byo time" {
+                let previous_byo_time = timer.byo_time_left;
+                sleep_ms(10);
+                timer.adjust_time();
+                assert_that(timer.byo_time_left, is(equal_to(previous_byo_time)));
+            }
+
+            it "doesn't change the byo stones" {
+                let previous_byo_stones = timer.byo_stones_left;
+                sleep_ms(10);
+                timer.adjust_time();
+                assert_that(timer.byo_stones_left, is(equal_to(previous_byo_stones)));
+            }
+
+        }
+
+        describe! over_time {
+
+            before_each {
+                timer.setup(1, 1, 10);
+                timer.main_time_left = 1;
+            }
+
+            it "sets the main time to zero" {
+                sleep_ms(10);
+                timer.adjust_time();
+                assert_that(timer.main_time_left, is(equal_to(0)));
+            }
+
+            it "reduces the byo time by the remaining amount" {
+                let previous_byo_time = timer.byo_time_left;
+                sleep_ms(10);
+                let elapsed = timer.time_stamp.to(PreciseTime::now()).num_milliseconds();
+                timer.adjust_time();
+                let expected_byo_time_left = (previous_byo_time - 1 - elapsed) as f32;
+                assert_that(timer.byo_time_left as f32, is(close_to(expected_byo_time_left, 5.0)));
+            }
+
+            it "reduces the number of byo stones" {
+                sleep_ms(10);
+                timer.adjust_time();
+                assert_that(timer.byo_stones_left, is(equal_to(9)));
+            }
+
+        }
+
+        describe! last_stone_in_overtime {
+
+            before_each {
+                timer.setup(0, 1, 10);
+                timer.byo_stones_left = 1;
+                timer.byo_time_left = 100;
+                sleep_ms(10);
+                timer.adjust_time();
+            }
+
+            it "resets the byo time" {
+                assert_that(timer.byo_time_left, is(equal_to(1_000)));
+            }
+
+            it "resets the byo stones" {
+                assert_that(timer.byo_stones_left, is(equal_to(10)));
+            }
+        }
+
+    }
+
+    describe! ran_out_of_time {
+
+        it "returns false if there's still time left" {
+            timer.current_budget = Duration::seconds(1);
+            assert!(!timer.ran_out_of_time(0.5));
+        }
+
+        it "returns true if the time is up" {
+            timer.current_budget = Duration::milliseconds(1);
+            sleep_ms(10);
+            assert!(timer.ran_out_of_time(0.5));
+        }
+
+        describe! over_5_percent_threshold {
+
+            before_each {
+                let win_ratio = config.time_control.fastplay5_thres + 0.01;
+            }
+
+            it "returns false if less than 5% of the time is up" {
+                timer.current_budget = Duration::seconds(1);
+                assert!(!timer.ran_out_of_time(win_ratio));
+            }
+
+            it "returns true if more than 5% of the time is up" {
+                timer.current_budget = Duration::milliseconds(100);
+                sleep_ms(10);
+                assert!(timer.ran_out_of_time(win_ratio));
+            }
+
+        }
+
+        describe! over_20_percent_threshold {
+
+            before_each {
+                let win_ratio = config.time_control.fastplay20_thres + 0.01;
+            }
+
+            it "returns false if less than 20% of the time is up" {
+                timer.current_budget = Duration::seconds(1);
+                assert!(!timer.ran_out_of_time(win_ratio));
+            }
+
+            it "returns false if more than 5% but less than 20% of the time is up" {
+                timer.current_budget = Duration::milliseconds(100);
+                sleep_ms(10);
+                assert!(!timer.ran_out_of_time(win_ratio));
+            }
+
+            it "returns true if more than 20% of the time is up" {
+                timer.current_budget = Duration::milliseconds(50);
+                sleep_ms(12);
+                assert!(timer.ran_out_of_time(win_ratio));
+            }
+
+        }
+
+    }
 }

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -34,13 +34,6 @@ fn config() -> Arc<Config> {
 }
 
 #[test]
-fn the_timer_doesnt_start_on_new() {
-    let clock = Timer::new(config()).clock;
-    assert!(clock.start.is_none());
-    assert!(clock.end.is_none());
-}
-
-#[test]
 fn the_timer_has_a_default_of_5_min_sudden_death() {
     let timer = Timer::new(config());
     assert_eq!(5*60*1000, timer.main_time);
@@ -49,7 +42,7 @@ fn the_timer_has_a_default_of_5_min_sudden_death() {
 }
 
 #[test]
-fn reset_stops_the_clock_and_resets_everything() {
+fn reset_resets_everything() {
     let mut timer = Timer::new(config());
     timer.main_time_left  = 1;
     timer.byo_time_left   = 1;
@@ -58,7 +51,6 @@ fn reset_stops_the_clock_and_resets_everything() {
     assert_eq!(timer.main_time, timer.main_time_left);
     assert_eq!(timer.byo_time, timer.byo_time_left);
     assert_eq!(timer.byo_stones, timer.byo_stones_left);
-    assert!(timer.clock.end.is_some());
 }
 
 #[test]
@@ -74,7 +66,6 @@ fn update_converts_to_ms_and_resets_everything() {
     assert_eq!(2000, timer.byo_time_left);
     assert_eq!(2, timer.byo_stones);
     assert_eq!(2, timer.byo_stones_left);
-    assert!(timer.clock.end.is_some());
 }
 
 #[test]
@@ -95,35 +86,13 @@ fn update_sets_the_byo_time() {
 
 
 #[test]
-fn update_starts_the_clock() {
-    let mut timer = Timer::new(config());
-    timer.update(1, 0);
-    assert!(timer.clock.start.is_some());
-    assert!(timer.clock.end.is_none());
-}
-
-#[test]
-fn start_starts_the_clock() {
-    let mut timer = Timer::new(config());
-    timer.start();
-    assert!(timer.clock.start.is_some());
-    assert!(timer.clock.end.is_none());
-}
-
-#[test]
 fn stop_changes_the_time_left() {
     let mut timer = Timer::new(config());
-    timer.start();
+    let info = TestGameInfo::new(0);
+    timer.start(&info);
     sleep(Duration::from_millis(10));
     timer.stop();
     assert!(timer.main_time_left < timer.main_time);
-}
-
-#[test]
-fn stop_stops_the_clock() {
-    let mut timer = Timer::new(config());
-    timer.stop();
-    assert!(timer.clock.end.is_some());
 }
 
 #[test]

--- a/src/timer/test.rs
+++ b/src/timer/test.rs
@@ -336,8 +336,8 @@ describe! timer {
             }
 
             it "returns false if more than 5% but less than 20% of the time is up" {
-                timer.current_budget = Duration::milliseconds(100);
-                sleep_ms(10);
+                timer.current_budget = Duration::milliseconds(1000);
+                sleep_ms(55);
                 assert!(!timer.ran_out_of_time(win_ratio));
             }
 


### PR DESCRIPTION
The code to check if the time is up is now in `Timer` and not in `EngineImpl` anymore. This seems to be a better place. Especially when we need to add more criteria it's nice as we don't have to change the engine at all. Testing is also simpler with this setup.