### PR TITLE
Quit program on EOF or Ctrl-D

### DIFF
--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -39,7 +39,9 @@ impl Driver {
         loop {
             command.clear();
             reader.read_line(&mut command).unwrap();
-
+            if command.is_empty() {
+                return; // EOF or Ctrl-D
+            }
             let response = interpreter.read(&*command);
 
             match response {


### PR DESCRIPTION
I discovered when preparing to use [afl.rs](https://github.com/frewsxcv/afl.rs) (to find bugs like #266) that we only quit when the GTP command `quit` is sent and not on EOF or Ctrl-D.