### PR TITLE
Prior calculation in the engine loop

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -155,7 +155,9 @@ impl Engine {
                         &path,
                         nodes_added,
                         &playout_result);
-                    let (path, moves, nodes_added) = self.root.find_leaf_and_expand(game, self.matcher.clone());
+                    let (path, moves, nodes_added, child_moves) = self.root.find_leaf_and_expand(game);
+                    let priors = prior::calculate(&moves, game, child_moves, &self.matcher, &self.config);
+                    self.root.record_priors(&path, priors);
                     let message = Message::RunPlayout {
                         path: path,
                         moves: moves,

--- a/src/engine/prior/mod.rs
+++ b/src/engine/prior/mod.rs
@@ -23,6 +23,7 @@ use board::Board;
 use board::Empty;
 use board::Move;
 use config::Config;
+use game::Game;
 use patterns::Matcher;
 
 use std::sync::Arc;
@@ -41,7 +42,9 @@ impl Prior {
             plays: 0,
             wins: 0,
         };
-        prior.calculate(board, m, matcher, &config);
+        if !m.is_pass() {
+            prior.calculate(board, m, matcher, &config);
+        }
         prior
     }
 
@@ -100,9 +103,13 @@ impl Prior {
     }
 }
 
-pub fn calculate(moves: Vec<Move>, board: &Board, matcher: &Arc<Matcher>, config: &Arc<Config>) -> Vec<Prior> {
-    let mut priors: Vec<Prior> = moves.iter()
-        .map(|m| Prior::new(board, m, matcher, config.clone()))
+pub fn calculate(moves: &Vec<Move>, game: &Game, child_moves: Vec<Move>, matcher: &Arc<Matcher>, config: &Arc<Config>) -> Vec<Prior> {
+    let mut board = game.board();
+    for &m in moves.iter() {
+        board.play_legal_move(m);
+    }
+    let mut priors: Vec<Prior> = child_moves.iter()
+        .map(|m| Prior::new(&board, m, matcher, config.clone()))
         .collect();
     let color = board.next_player().opposite();
     let in_danger = board.chains().iter()


### PR DESCRIPTION
Move the prior calculation into the engine search loop. That way we can easily move the actual prior calculation into the worker threads as the next step.