### PR TITLE
Move prior calculation into the workers

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -53,7 +53,7 @@ set -x
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko"
-IOMRASCALAI="./target/release/iomrascalai --log --rules chinese"
+IOMRASCALAI="cargo run --release -- --log --rules chinese"
 REFEREE="$GNUGO"
 
 gogui-twogtp -auto -black "$GNUGO" -white "$IOMRASCALAI" \

--- a/bin/play
+++ b/bin/play
@@ -45,7 +45,7 @@ fi
 
 cargo build --release
 
-IOMRASCALAI="./target/release/iomrascalai --log --rules chinese"
+IOMRASCALAI="cargo run --release -- --log --rules chinese"
 
 set -x
 

--- a/bin/play-gnugo
+++ b/bin/play-gnugo
@@ -45,7 +45,7 @@ fi
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko"
-IOMRASCALAI="./target/release/iomrascalai --log --rules chinese --gfx"
+IOMRASCALAI="cargo run --release -- --log --rules chinese --gfx"
 
 
 TWOGTP="gogui-twogtp -black \"$GNUGO\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"

--- a/bin/play-gnugo-cgos-rules
+++ b/bin/play-gnugo-cgos-rules
@@ -45,7 +45,7 @@ fi
 cargo build --release
 
 GNUGO="gnugo --mode gtp --level 0 --chinese-rules --positional-superko --capture-all-dead --score aftermath --play-out-aftermath"
-IOMRASCALAI="./target/release/iomrascalai --log --gfx --rules chinese"
+IOMRASCALAI="cargo run --release -- --log --gfx --rules chinese"
 
 
 TWOGTP="gogui-twogtp -black \"$GNUGO\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"

--- a/bin/play-self
+++ b/bin/play-self
@@ -44,7 +44,7 @@ fi
 
 cargo build --release
 
-IOMRASCALAI="./target/release/iomrascalai --log --gfx"
+IOMRASCALAI="cargo run --release -- --log --gfx"
 
 TWOGTP="gogui-twogtp -black \"$IOMRASCALAI\" -white \"$IOMRASCALAI\" -verbose -size $SIZE -time $TIME"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -333,9 +333,9 @@ pub struct Config {
     /// Holds a configuration object that contains everything related
     /// to estimating the score of a board
     pub scoring: ScoringConfig,
-    /// The number of threads to use. The best results are achieved
-    /// right now if this is the same number as the number of (logical)
-    /// cores the computer has that the program runs on.
+    /// The number of threads to use for the workers. The default is
+    /// one less that the number of cores of the machine you're running
+    /// on.
     pub threads: usize,
     /// Holds a configuration object that contains everything related
     /// to allocating the time to use for the next move, stopping the
@@ -381,7 +381,9 @@ impl Config {
     fn new(toml_str: String, default_toml_str: String, log: bool, gfx: bool, ruleset: Ruleset) -> Config {
         let opts = toml::Parser::new(&toml_str).parse().unwrap();
         let default_table = toml::Parser::new(&default_toml_str).parse().unwrap();
-        let threads = toml::Parser::new(&format!("threads = {}", num_cpus::get())).parse().unwrap();
+        let threads = toml::Parser::new(
+            &format!("threads = {}", num_cpus::get()-1)
+        ).parse().unwrap();
         let mut table = toml::Table::new();
         table.extend(default_table.clone());
         table.extend(threads.clone());

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -35,6 +35,7 @@ use patterns::Matcher;
 use playout::Playout;
 use playout::PlayoutResult;
 use ruleset::KgsChinese;
+use self::prior::Prior;
 use self::worker::Worker;
 use timer::Timer;
 
@@ -74,6 +75,12 @@ pub enum Message {
         moves: Vec<Move>,
         nodes_added: usize,
         path: Vec<usize>,
+    },
+    CalculatePriors {
+        child_moves: Vec<Move>,
+        id: usize,
+        moves: Vec<Move>,
+        path: Vec<usize>,
     }
 }
 pub enum Answer {
@@ -81,7 +88,13 @@ pub enum Answer {
         nodes_added: usize,
         path: Vec<usize>,
         playout_result: PlayoutResult
-    }
+    },
+    CalculatePriors {
+        moves: Vec<Move>,
+        path: Vec<usize>,
+        priors: Vec<Prior>,
+    },
+    SpinUp
 }
 pub type Response = (Answer, usize, Sender<Message>);
 
@@ -148,7 +161,25 @@ impl Engine {
         let (answer, id, send_to_thread) = response;
         // Ignore responses from the previous genmove
         if self.id == id {
-            match answer {
+            let message = match answer {
+                Answer::SpinUp => {
+                    let (path, moves, nodes_added, child_moves) = self.root.find_leaf_and_expand(game);
+                    if nodes_added > 0 {
+                        Message::CalculatePriors {
+                            child_moves: child_moves,
+                            id: self.id,
+                            moves: moves,
+                            path: path,
+                        }
+                    } else {
+                        Message::RunPlayout {
+                            id: self.id,
+                            moves: moves,
+                            nodes_added: nodes_added,
+                            path: path,
+                        }
+                    }
+                },
                 Answer::RunPlayout {path, nodes_added, playout_result} => {
                     self.ownership.merge(playout_result.score());
                     self.root.record_on_path(
@@ -156,17 +187,35 @@ impl Engine {
                         nodes_added,
                         &playout_result);
                     let (path, moves, nodes_added, child_moves) = self.root.find_leaf_and_expand(game);
-                    let priors = prior::calculate(&moves, game, child_moves, &self.matcher, &self.config);
+                    if nodes_added > 0 {
+                        Message::CalculatePriors {
+                            child_moves: child_moves,
+                            id: self.id,
+                            moves: moves,
+                            path: path,
+                        }
+                    } else {
+                        Message::RunPlayout {
+                            id: self.id,
+                            moves: moves,
+                            nodes_added: nodes_added,
+                            path: path,
+                        }
+                    }
+                },
+                Answer::CalculatePriors {path, moves, priors} => {
+                    let nodes_added = priors.len();
                     self.root.record_priors(&path, priors);
-                    let message = Message::RunPlayout {
-                        path: path,
+                    Message::RunPlayout {
+                        id: self.id,
                         moves: moves,
                         nodes_added: nodes_added,
-                        id: self.id
-                    };
-                    check!(self.config, send_to_thread.send(message));
+                        path: path,
+                    }
+
                 }
-            }
+            };
+            check!(self.config, send_to_thread.send(message));
         }
     }
 
@@ -250,6 +299,7 @@ impl Engine {
         let mut worker = Worker::new(
             &self.config,
             &self.playout,
+            &self.matcher,
             self.id,
             board,
             &self.send_to_main

--- a/src/engine/node/mod.rs
+++ b/src/engine/node/mod.rs
@@ -139,20 +139,18 @@ impl Node {
         }
     }
 
-    pub fn find_leaf_and_expand(&mut self, game: &Game) -> (Vec<usize>, Vec<Move>, usize, Vec<Move>) {
+    pub fn find_leaf_and_expand(&mut self, game: &Game) -> (Vec<usize>, Vec<Move>, Vec<Move>) {
         let (path, moves, leaf) = self.find_leaf_and_mark(vec!(), vec!());
         let mut board = game.board();
         for &m in moves.iter() {
             board.play_legal_move(m);
         }
-        let previous_desc = leaf.descendants;
         let (not_terminal, child_moves) = leaf.expand(&board);
         if !not_terminal {
             let is_win = board.winner() == leaf.color();
             leaf.mark_as_terminal(is_win);
         }
-        let new_desc = leaf.descendants - previous_desc;
-        (path, moves, new_desc, child_moves)
+        (path, moves, child_moves)
     }
 
     /// Finds the next leave to simulate. To make sure that different

--- a/src/engine/node/test.rs
+++ b/src/engine/node/test.rs
@@ -131,8 +131,7 @@ fn find_leaf_and_expand_sets_play_on_the_root() {
 fn find_leaf_and_expand_returns_the_number_of_nodes_added() {
     let game = Game::new(2, 0.5, KgsChinese);
     let mut root = Node::root(&game, Black, config());
-    let (_,_,count, child_moves) = root.find_leaf_and_expand(&game);
-    assert_eq!(4, count);
+    let (_,_, child_moves) = root.find_leaf_and_expand(&game);
     assert_eq!(4, child_moves.len());
 }
 

--- a/src/engine/prior/mod.rs
+++ b/src/engine/prior/mod.rs
@@ -23,7 +23,6 @@ use board::Board;
 use board::Empty;
 use board::Move;
 use config::Config;
-use game::Game;
 use patterns::Matcher;
 
 use std::sync::Arc;
@@ -103,11 +102,7 @@ impl Prior {
     }
 }
 
-pub fn calculate(moves: &Vec<Move>, game: &Game, child_moves: Vec<Move>, matcher: &Arc<Matcher>, config: &Arc<Config>) -> Vec<Prior> {
-    let mut board = game.board();
-    for &m in moves.iter() {
-        board.play_legal_move(m);
-    }
+pub fn calculate(board: Board, child_moves: Vec<Move>, matcher: &Arc<Matcher>, config: &Arc<Config>) -> Vec<Prior> {
     let mut priors: Vec<Prior> = child_moves.iter()
         .map(|m| Prior::new(&board, m, matcher, config.clone()))
         .collect();

--- a/src/playout/mod.rs
+++ b/src/playout/mod.rs
@@ -229,13 +229,6 @@ impl PlayoutResult {
         }
     }
 
-    pub fn empty() -> PlayoutResult {
-        PlayoutResult {
-            amaf: HashMap::new(),
-            score: Score::empty(),
-        }
-    }
-
     pub fn winner(&self) -> Color {
         self.score.color()
     }

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -57,16 +57,6 @@ impl Score {
         }
     }
 
-    pub fn empty() -> Score {
-        Score {
-            black_stones: 0,
-            komi: 0.0,
-            owner: vec![],
-            size: 0,
-            white_stones: 0,
-        }
-    }
-
     pub fn color(&self) -> Color {
         let white_adjusted = self.white_stones as f32 + self.komi;
         if self.black_stones as f32 == white_adjusted {

--- a/src/score/test.rs
+++ b/src/score/test.rs
@@ -192,9 +192,13 @@ describe! score {
     describe! adjusted {
 
         before_each {
-            let mut score = Score::empty();
-            score.komi = 6.5;
-            score.size = 9;
+            let mut score = Score {
+                black_stones: 0,
+                komi: 6.5,
+                owner: vec!(),
+                size: 9,
+                white_stones: 0,
+            };
         }
 
         it "returns the correct score when black wins" {


### PR DESCRIPTION
The following things still need to be done:

- [x] Fix the tests
- [ ] Write some new tests
- [x] Move the code from the match block in `Engine#handle_response` into separate methods
- [x] Do some profiling to figure out if sending all that data between the threads has a high overhead
- [ ] Try running with `expand_after` set to 2 to see if this still works when the leafs aren't expanded right away (and compare to setting `expand_after` to 2 on the `master` branch)
- [ ] Run the benchmarks!