### PR TITLE
Set number of threads using a command line switch

### DIFF
--- a/misc/scripts/optimize_threads.rb
+++ b/misc/scripts/optimize_threads.rb
@@ -10,11 +10,7 @@ THREADS = ARGV[0] ? ARGV[0].to_i : 36
 INPUT = "boardsize 9\nclear_board\ntime_settings 300 0 0\ngenmove b\nboardsize 13\nclear_board\ntime_settings 600 0 0\ngenmove b\nboardsize 19\nclear_board\ntime_settings 1200 0 0\ngenmove b\n"
 
 def run(threads)
-  cfg = "config.toml"
-  File.open(cfg, "w") do |f|
-    f.puts "threads = #{threads}"
-  end
-  cmd = "cargo run --release -- -l -c #{cfg}"
+  cmd = "cargo run --release -- -l -t #{threads}"
   stderr = Open3.popen3(cmd) {|i,o,e,t| i.puts(INPUT); i.close; e.read }
   stderr.split($/).find_all do |l|
     l =~/pps per thread/

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,12 @@ fn main() {
     opts.optflag("l", "log", "Print logging information to STDERR");
     opts.optflag("v", "version", "Print the version number");
     opts.optopt("c", "config", "Config file", "FILE");
-    opts.optopt("t", "threads", "Number of worker threads", "INTEGER");
+    opts.optopt(
+        "t",
+        "threads",
+        "Number of worker threads (overrides value set in the config file)",
+        "INTEGER"
+    );
     let r_expl = format!("cgos|chinese|tromp-taylor (defaults to {})", default_ruleset);
     opts.optopt("r", "rules", "Pick ruleset", &r_expl);
     let args : Vec<String> = args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn main() {
     opts.optflag("l", "log", "Print logging information to STDERR");
     opts.optflag("v", "version", "Print the version number");
     opts.optopt("c", "config", "Config file", "FILE");
+    opts.optopt("t", "threads", "Number of worker threads", "INTEGER");
     let r_expl = format!("cgos|chinese|tromp-taylor (defaults to {})", default_ruleset);
     opts.optopt("r", "rules", "Pick ruleset", &r_expl);
     let args : Vec<String> = args().collect();
@@ -118,14 +119,24 @@ fn main() {
         },
         None => default_ruleset
     };
+    let threads = match matches.opt_str("t") {
+        Some(ts) => match ts.parse() {
+            Ok(threads) => threads,
+            Err(error) => {
+                println!("{}", error);
+                exit(1);
+            }
+        },
+        None => num_cpus::get() - 1
+    };
 
     let config_file_opt = matches.opt_str("c");
     let config = match config_file_opt {
         Some(filename) => {
-            Config::from_file(filename, log, gfx, ruleset)
+            Config::from_file(filename, log, gfx, ruleset, threads)
         },
         None => {
-            Config::default(log, gfx, ruleset)
+            Config::default(log, gfx, ruleset, threads)
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,13 +121,13 @@ fn main() {
     };
     let threads = match matches.opt_str("t") {
         Some(ts) => match ts.parse() {
-            Ok(threads) => threads,
+            Ok(threads) => Some(threads),
             Err(error) => {
                 println!("{}", error);
                 exit(1);
             }
         },
-        None => num_cpus::get() - 1
+        None => None
     };
 
     let config_file_opt = matches.opt_str("c");


### PR DESCRIPTION
Setting the number of threads to use is machine dependent and setting it via the command line is just easier.