### PR TITLE
Remove kgs-chat command

### DIFF
--- a/src/gtp/mod.rs
+++ b/src/gtp/mod.rs
@@ -64,7 +64,6 @@ impl<'a> GTPInterpreter<'a> {
             "genmove",
             "gogui-analyze_commands",
             "imrscl-ownership",
-            "kgs-chat",
             "known_command",
             "komi",
             "list_commands",
@@ -125,7 +124,6 @@ impl<'a> GTPInterpreter<'a> {
             "genmove" => self.execute_genmove(arguments),
             "gogui-analyze_commands" => self.execute_gogui_analyze_commands(arguments),
             "imrscl-ownership" => self.execute_imrscl_ownership(arguments),
-            "kgs-chat" => self.execute_kgs_chat(arguments),
             "known_command" => self.execute_known_command(arguments),
             "komi" => self.execute_komi(arguments),
             "list_commands" => self.execute_list_commands(arguments),
@@ -141,10 +139,6 @@ impl<'a> GTPInterpreter<'a> {
             _ => Err("unknown command".to_string())
         }
 
-    }
-
-    fn execute_kgs_chat(&mut self, _: &[&str]) -> Result<String, String> {
-        Ok("I'm a program. I cannot talk".to_string())
     }
 
     fn execute_name(&mut self, _: &[&str]) -> Result<String, String> {

--- a/src/gtp/test.rs
+++ b/src/gtp/test.rs
@@ -61,14 +61,6 @@ describe! interpreter {
             assert_that(response, is(equal_to(err("empty command"))));
         }
 
-        describe! kgs_chat {
-
-            it "returns a static string" {
-                let response = interpreter.read("kgs-chat private user the rest is the message\n");
-                assert_that(response, is(equal_to(ok("I'm a program. I cannot talk"))));
-            }
-        }
-
         describe! loadsgf {
 
             it "wrong file" {
@@ -211,7 +203,7 @@ describe! interpreter {
 
             it "no newline at end" {
                 let response = interpreter.read("list_commands\n");
-                let expected = "boardsize\nclear_board\nfinal_score\nfinal_status_list\ngenmove\ngogui-analyze_commands\nimrscl-ownership\nkgs-chat\nknown_command\nkomi\nlist_commands\nloadsgf\nname\nplay\nprotocol_version\nquit\nshowboard\ntime_left\ntime_settings\nversion";
+                let expected = "boardsize\nclear_board\nfinal_score\nfinal_status_list\ngenmove\ngogui-analyze_commands\nimrscl-ownership\nknown_command\nkomi\nlist_commands\nloadsgf\nname\nplay\nprotocol_version\nquit\nshowboard\ntime_left\ntime_settings\nversion";
                 assert_that(response, is(equal_to(ok(expected))));
             }
 


### PR DESCRIPTION
This has to go as it makes the kgsGtp client (at least version 3.5.20) crash.

Closes #287

<!---
@huboard:{"order":288.0,"milestone_order":288,"custom_state":""}
-->
