### PR TITLE
Start workers once

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -284,7 +284,6 @@ impl Engine {
     }
 
     fn spin_down(&mut self) {
-        self.id += 1;
         for direct_message_sender in &self.direct_message_senders {
             check!(self.config, direct_message_sender.send(DirectMessage::SpinDown));
         }
@@ -296,6 +295,11 @@ impl Engine {
         for _ in 0..self.config.threads {
             self.spin_up_worker();
         }
+        self.send_new_state_to_workers(game);
+    }
+
+    fn send_new_state_to_workers(&mut self, game: &Game) {
+        self.id += 1;
         for direct_message_sender in &self.direct_message_senders {
             let dm = DirectMessage::NewState {
                 board: game.board(),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -300,7 +300,10 @@ impl Engine {
             self.spin_up_worker();
         }
         for direct_message_sender in &self.direct_message_senders {
-            let dm = DirectMessage::NewState { board: game.board() };
+            let dm = DirectMessage::NewState {
+                board: game.board(),
+                id: self.id,
+            };
             check!(self.config, direct_message_sender.send(dm));
         }
     }
@@ -310,7 +313,6 @@ impl Engine {
             &self.config,
             &self.playout,
             &self.matcher,
-            self.id,
             &self.send_to_main
         );
         let (send_direct_message, receive_direct_message) = channel();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -22,7 +22,6 @@
 
 pub use self::controller::EngineController;
 pub use self::node::Node;
-use board::Board;
 use board::Color;
 use board::Move;
 use board::NoMove;
@@ -298,17 +297,20 @@ impl Engine {
     fn spin_up(&mut self, game: &Game) {
         self.direct_message_senders = vec!();
         for _ in 0..self.config.threads {
-            self.spin_up_worker(game.board());
+            self.spin_up_worker();
+        }
+        for direct_message_sender in &self.direct_message_senders {
+            let dm = DirectMessage::NewState { board: game.board() };
+            check!(self.config, direct_message_sender.send(dm));
         }
     }
 
-    fn spin_up_worker(&mut self, board: Board) {
+    fn spin_up_worker(&mut self) {
         let mut worker = Worker::new(
             &self.config,
             &self.playout,
             &self.matcher,
             self.id,
-            board,
             &self.send_to_main
         );
         let (send_direct_message, receive_direct_message) = channel();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -193,7 +193,6 @@ impl Engine {
                     let nodes_added = priors.len();
                     self.root.record_priors(&path, priors);
                     Message::RunPlayout {
-                        id: self.id,
                         moves: moves,
                         nodes_added: nodes_added,
                         path: path,
@@ -211,13 +210,11 @@ impl Engine {
         if nodes_added > 0 {
             Message::CalculatePriors {
                 child_moves: child_moves,
-                id: self.id,
                 moves: moves,
                 path: path,
             }
         } else {
             Message::RunPlayout {
-                id: self.id,
                 moves: moves,
                 nodes_added: nodes_added,
                 path: path,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -178,7 +178,7 @@ impl Engine {
         // Ignore responses from the previous genmove
         if self.id == id {
             let message = match answer {
-                Answer::SpinUp => {
+                Answer::NewState => {
                     self.expand(game)
                 },
                 Answer::RunPlayout {path, nodes_added, playout_result} => {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -34,10 +34,11 @@ use game::Game;
 use ownership::OwnershipStatistics;
 use patterns::SmallPatternMatcher;
 use playout::Playout;
-use playout::PlayoutResult;
 use ruleset::KgsChinese;
 use score::FinalScore;
-use self::prior::Prior;
+use self::worker::Answer;
+use self::worker::Message;
+use self::worker::Response;
 use self::worker::Worker;
 use timer::Timer;
 
@@ -70,35 +71,6 @@ mod controller;
 mod node;
 mod prior;
 mod worker;
-
-pub enum Message {
-    RunPlayout {
-        id: usize,
-        moves: Vec<Move>,
-        nodes_added: usize,
-        path: Vec<usize>,
-    },
-    CalculatePriors {
-        child_moves: Vec<Move>,
-        id: usize,
-        moves: Vec<Move>,
-        path: Vec<usize>,
-    }
-}
-pub enum Answer {
-    RunPlayout {
-        nodes_added: usize,
-        path: Vec<usize>,
-        playout_result: PlayoutResult
-    },
-    CalculatePriors {
-        moves: Vec<Move>,
-        path: Vec<usize>,
-        priors: Vec<Prior>,
-    },
-    SpinUp
-}
-pub type Response = (Answer, usize, Sender<Message>);
 
 pub struct Engine {
     config: Arc<Config>,

--- a/src/engine/worker/mod.rs
+++ b/src/engine/worker/mod.rs
@@ -24,10 +24,9 @@ use board::Move;
 use config::Config;
 use patterns::SmallPatternMatcher;
 use playout::Playout;
-use super::Answer;
-use super::Message;
-use super::Response;
+use playout::PlayoutResult;
 use super::prior;
+use super::prior::Prior;
 
 use rand::XorShiftRng;
 use rand::weak_rng;
@@ -35,6 +34,35 @@ use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
+
+pub enum Message {
+    RunPlayout {
+        id: usize,
+        moves: Vec<Move>,
+        nodes_added: usize,
+        path: Vec<usize>,
+    },
+    CalculatePriors {
+        child_moves: Vec<Move>,
+        id: usize,
+        moves: Vec<Move>,
+        path: Vec<usize>,
+    }
+}
+pub enum Answer {
+    RunPlayout {
+        nodes_added: usize,
+        path: Vec<usize>,
+        playout_result: PlayoutResult
+    },
+    CalculatePriors {
+        moves: Vec<Move>,
+        path: Vec<usize>,
+        priors: Vec<Prior>,
+    },
+    SpinUp
+}
+pub type Response = (Answer, usize, Sender<Message>);
 
 pub struct Worker {
     board: Board,


### PR DESCRIPTION
Up to now the worker threads were started for each `genmove` command. This is quite a waste and will become more problematic the higher the setup cost for a worker is. For example when initialising a caffe DCNN (see #294). This change reworks the communication between then engine and the workers such that they can be started once when then program is started.

I will only merge this once #279 is done as it could potentially mess up the results otherwise.