### PR TITLE
Try getting kcov to upload code coverage to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - bash ci/script.sh
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo --verify; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/iomrascalai-*; fi
 before_deploy:
   - bash ci/before_deploy.sh
 deploy:


### PR DESCRIPTION
For some reason [travis-cargo](https://github.com/huonw/travis-cargo/) doesn't upload to coveralls.io anymore. This is the temporary fix until it's fixed in travis-cargo itself.