### PR TITLE
Add current commit SHA to the version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Urban Hafner <contact@urbanhafner.com>",
 homepage = "https://github.com/ujh/iomrascalai"
 repository = "https://github.com/ujh/iomrascalai"
 license = "GPL-3.0+"
+build = "build.rs"
 
 [dependencies]
 enum_primitive  = "*"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::Path;
+use std::process::Command;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--short")
+        .arg("HEAD")
+        .output()
+        .expect("failed to execute git rev-parse");
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("REVISION");
+    let mut f = File::create(&dest_path).unwrap();
+    let data = String::from_utf8(output.stdout).unwrap();
+    let without_newline = data.lines().next().unwrap();
+    f.write_all(without_newline.as_bytes()).unwrap();
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -21,5 +21,5 @@
  ************************************************************************/
 
 pub fn version() -> &'static str {
-    "0.3.2"
+    concat!("0.3.2 (", include_str!(concat!(env!("OUT_DIR"), "/REVISION")), ")")
 }


### PR DESCRIPTION
When running the benchmarks using `gogui-twogtp` the version is stored in the output files. If we ever want to run two version of Iomrascálaí against each other we need a way to distinguish them by their version number. The easiest way seems to be to add the SHA of the current HEAD to the version. It was also a nice way to try out creating a build script. 😁 