### PR TITLE
Remove plays again

### DIFF
--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -29,7 +29,6 @@ vacant_point_scaling_factor = 0.794819
 
 expand_after = 6
 rave_equiv = 24.8829
-score_weight = 0.0653414
 
 [scoring]
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -82,9 +82,6 @@ pub struct TreeConfig {
     /// algorithm. There's no clear way to set this value. It's best
     /// to use parameter optimization to find the best value.
     pub rave_equiv: f32,
-    /// A float between 0.0 and 1.0 that is the part of a win recorded
-    /// in the tree nodes to signify the score of the playout.
-    pub score_weight: f32,
 }
 
 impl TreeConfig {
@@ -98,7 +95,6 @@ impl TreeConfig {
         TreeConfig {
             expand_after: Self::as_integer(&table, "expand_after"),
             rave_equiv: Self::as_float(&table, "rave_equiv"),
-            score_weight: Self::as_float(&table, "score_weight"),
         }
     }
 

--- a/src/engine/node/test.rs
+++ b/src/engine/node/test.rs
@@ -79,7 +79,7 @@ fn expand_doesnt_add_children_if_threshold_not_met() {
     let config = expand_after(1);
     let game = Game::new(2, 0.5, KgsChinese);
     let mut node = Node::new(Pass(Black), config);
-    node.plays = 0.0;
+    node.playouts = 0;
     node.expand(&game.board());
     assert_eq!(0, node.children.len());
 }
@@ -88,7 +88,7 @@ fn expand_doesnt_add_children_if_threshold_not_met() {
 fn expand_adds_children_if_threshold_is_met() {
     let game = Game::new(2, 0.5, KgsChinese);
     let mut node = Node::new(Pass(Black), config());
-    node.plays = 2.0;
+    node.playouts = 2;
     node.expand(&game.board());
     assert_eq!(5, node.children.len());
 }
@@ -125,7 +125,7 @@ fn find_leaf_and_expand_sets_play_on_the_root() {
     let game = Game::new(2, 0.5, KgsChinese);
     let mut root = Node::root(&game, Black, config());
     root.find_leaf_and_expand(&game);
-    assert_eq!(2.0, root.plays);
+    assert_eq!(2, root.playouts);
 }
 
 #[test]
@@ -140,8 +140,8 @@ fn find_leaf_and_expand_returns_the_number_of_nodes_added() {
 fn the_root_needs_to_be_initialized_with_1_plays_for_correct_uct_calculations() {
     let game = Game::new(2, 0.5, KgsChinese);
     let root = Node::root(&game, Black, config());
-    assert_eq!(1.0, root.plays);
-    assert_eq!(1.0, root.wins);
+    assert_eq!(1, root.playouts);
+    assert_eq!(1, root.wins);
  }
 
 #[test]
@@ -156,9 +156,7 @@ fn no_super_ko_violations_in_the_children_of_the_root() {
 describe! record_on_path {
 
     before_each {
-        let mut c = Config::test_config();
-        c.tree.score_weight = 0.0;
-        let config = Arc::new(c);
+        let config = Arc::new(Config::test_config());
     }
 
     it "only records wins for the correct color" {
@@ -173,17 +171,17 @@ describe! record_on_path {
         let score = board.score();
         let playout_result = PlayoutResult::new(score, HashMap::new());
         root.record_on_path(&vec!(0, 0), 0, &playout_result);
-        assert_eq!(1.0, root.wins);
-        assert_eq!(0.0, root.children[0].wins);
-        assert_eq!(1.0, root.children[0].children[0].wins);
+        assert_eq!(1, root.wins);
+        assert_eq!(0, root.children[0].wins);
+        assert_eq!(1, root.children[0].children[0].wins);
 
         let board = Board::new(9, 6.5, KgsChinese);
         let score = board.score();
         let playout_result = PlayoutResult::new(score, HashMap::new());
         root.record_on_path(&vec!(0, 0), 0, &playout_result);
-        assert_eq!(1.0, root.wins);
-        assert_eq!(1.0, root.children[0].wins);
-        assert_eq!(1.0, root.children[0].children[0].wins);
+        assert_eq!(1, root.wins);
+        assert_eq!(1, root.children[0].wins);
+        assert_eq!(1, root.children[0].children[0].wins);
     }
 
     it "updates the descendant counts" {

--- a/src/score/mod.rs
+++ b/src/score/mod.rs
@@ -40,7 +40,6 @@ pub struct Score {
     black_stones: usize,
     komi: f32,
     owner: Vec<Color>,
-    size: u8,
     white_stones: usize,
 }
 
@@ -52,7 +51,6 @@ impl Score {
             black_stones: bs,
             komi: board.komi(),
             owner: owners,
-            size: board.size(),
             white_stones: ws,
         }
     }
@@ -74,18 +72,6 @@ impl Score {
 
     fn score(&self) -> f32 {
         (self.black_stones as f32 - (self.white_stones as f32 + self.komi)).abs()
-    }
-
-    pub fn adjusted(&self) -> f32 {
-        let max = self.size as f32 * self.size as f32;
-        match self.color() {
-            White => {
-                self.score() / (max + self.komi)
-            },
-            _ => {
-                self.score() / max
-            }
-        }
     }
 
     fn score_tt(board: &Board) -> (usize, usize, Vec<Color>) {

--- a/src/score/test.rs
+++ b/src/score/test.rs
@@ -186,32 +186,4 @@ describe! score {
 
     }
 
-    describe! adjusted {
-
-        before_each {
-            let mut score = Score {
-                black_stones: 0,
-                komi: 6.5,
-                owner: vec!(),
-                size: 9,
-                white_stones: 0,
-            };
-        }
-
-        it "returns the correct score when black wins" {
-            score.black_stones = 10;
-            assert_that!(score.adjusted(), is(equal_to(0.043209877)));
-        }
-
-        it "returns the correct score when white wins" {
-            score.white_stones = 10;
-            assert_that!(score.adjusted(), is(equal_to(0.188571429)));
-        }
-
-        it "returns the correct score on a draw" {
-            score.komi = 7.0;
-            score.black_stones = 7;
-            assert_that!(score.adjusted(), is(equal_to(0.0)));
-        }
-    }
 }


### PR DESCRIPTION
`plays` was very similar to `playouts`. It just included a scaling factor to nudge the bot towards trying to produce wins that have a larger margin. That obviously didn't work so I think it makes sense to throw it out as it's just added complexity for no gain.

I also removed the `Node#mark_as_terminal` function because I couldn't figure out what it's purpose was. We'll have to wait for the benchmark results to see if I messed up. ;)