### PR TITLE
Command line option to run benchmark

### DIFF
--- a/src/gtp/driver.rs
+++ b/src/gtp/driver.rs
@@ -56,3 +56,23 @@ impl Driver {
 
     }
 }
+
+pub struct BenchmarkDriver;
+
+impl BenchmarkDriver {
+    pub fn new(config: Arc<Config>, engine: Engine, board_size: usize) {
+        let mut interpreter = GTPInterpreter::new(config, engine);
+        let time_settings = match board_size {
+            9 => 300,
+            13 => 600,
+            15 => 1020,
+            17 => 1440,
+            19 => 1800,
+            _ => unreachable!("board size not supported"),
+        };
+        interpreter.read(&format!("boardsize {}\n", board_size)).unwrap();
+        interpreter.read("clear_board\n").unwrap();
+        interpreter.read(&format!("time_settings {} 0 0 \n", time_settings)).unwrap();
+        interpreter.read("genmove b\n").unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ extern crate toml;
 // documentation.
 pub use config::*;
 use engine::Engine;
+use gtp::driver::BenchmarkDriver;
 use gtp::driver::Driver;
 use patterns::SmallPatternMatcher;
 use ruleset::Ruleset;
@@ -85,6 +86,7 @@ fn main() {
     );
     let r_expl = format!("cgos|chinese|tromp-taylor (defaults to {})", default_ruleset);
     opts.optopt("r", "rules", "Pick ruleset", &r_expl);
+    opts.optopt("b", "benchmark", "Run benchmark on provided board size", "INTEGER");
     let args : Vec<String> = args().collect();
 
     let (_, tail) = args.split_first().unwrap();
@@ -154,5 +156,14 @@ fn main() {
 
     config.log(format!("Current configuration: {:#?}", config));
 
-    Driver::new(config, engine);
+    match matches.opt_str("b") {
+        Some(bs) => match bs.parse() {
+            Ok(board_size) => BenchmarkDriver::new(config, engine, board_size),
+            Err(error) => {
+                println!("{}", error);
+                exit(1);
+            }
+        },
+        None => Driver::new(config, engine)
+    }
 }


### PR DESCRIPTION
Adds `-b SIZE` to the executable so that it's easier to profile.